### PR TITLE
Migrate rules from TFLint core

### DIFF
--- a/aws/mock/ec2.go
+++ b/aws/mock/ec2.go
@@ -735,6 +735,56 @@ func (mr *MockEC2APIMockRecorder) AssociateDhcpOptionsWithContext(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateDhcpOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateDhcpOptionsWithContext), varargs...)
 }
 
+// AssociateEnclaveCertificateIamRole mocks base method
+func (m *MockEC2API) AssociateEnclaveCertificateIamRole(arg0 *ec2.AssociateEnclaveCertificateIamRoleInput) (*ec2.AssociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssociateEnclaveCertificateIamRole", arg0)
+	ret0, _ := ret[0].(*ec2.AssociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateEnclaveCertificateIamRole indicates an expected call of AssociateEnclaveCertificateIamRole
+func (mr *MockEC2APIMockRecorder) AssociateEnclaveCertificateIamRole(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateEnclaveCertificateIamRole", reflect.TypeOf((*MockEC2API)(nil).AssociateEnclaveCertificateIamRole), arg0)
+}
+
+// AssociateEnclaveCertificateIamRoleRequest mocks base method
+func (m *MockEC2API) AssociateEnclaveCertificateIamRoleRequest(arg0 *ec2.AssociateEnclaveCertificateIamRoleInput) (*request.Request, *ec2.AssociateEnclaveCertificateIamRoleOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssociateEnclaveCertificateIamRoleRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateEnclaveCertificateIamRoleOutput)
+	return ret0, ret1
+}
+
+// AssociateEnclaveCertificateIamRoleRequest indicates an expected call of AssociateEnclaveCertificateIamRoleRequest
+func (mr *MockEC2APIMockRecorder) AssociateEnclaveCertificateIamRoleRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateEnclaveCertificateIamRoleRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateEnclaveCertificateIamRoleRequest), arg0)
+}
+
+// AssociateEnclaveCertificateIamRoleWithContext mocks base method
+func (m *MockEC2API) AssociateEnclaveCertificateIamRoleWithContext(arg0 context.Context, arg1 *ec2.AssociateEnclaveCertificateIamRoleInput, arg2 ...request.Option) (*ec2.AssociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AssociateEnclaveCertificateIamRoleWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AssociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateEnclaveCertificateIamRoleWithContext indicates an expected call of AssociateEnclaveCertificateIamRoleWithContext
+func (mr *MockEC2APIMockRecorder) AssociateEnclaveCertificateIamRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateEnclaveCertificateIamRoleWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateEnclaveCertificateIamRoleWithContext), varargs...)
+}
+
 // AssociateIamInstanceProfile mocks base method
 func (m *MockEC2API) AssociateIamInstanceProfile(arg0 *ec2.AssociateIamInstanceProfileInput) (*ec2.AssociateIamInstanceProfileOutput, error) {
 	m.ctrl.T.Helper()
@@ -16675,6 +16725,56 @@ func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetworkWithContext(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetworkWithContext), varargs...)
 }
 
+// DisassociateEnclaveCertificateIamRole mocks base method
+func (m *MockEC2API) DisassociateEnclaveCertificateIamRole(arg0 *ec2.DisassociateEnclaveCertificateIamRoleInput) (*ec2.DisassociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisassociateEnclaveCertificateIamRole", arg0)
+	ret0, _ := ret[0].(*ec2.DisassociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateEnclaveCertificateIamRole indicates an expected call of DisassociateEnclaveCertificateIamRole
+func (mr *MockEC2APIMockRecorder) DisassociateEnclaveCertificateIamRole(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateEnclaveCertificateIamRole", reflect.TypeOf((*MockEC2API)(nil).DisassociateEnclaveCertificateIamRole), arg0)
+}
+
+// DisassociateEnclaveCertificateIamRoleRequest mocks base method
+func (m *MockEC2API) DisassociateEnclaveCertificateIamRoleRequest(arg0 *ec2.DisassociateEnclaveCertificateIamRoleInput) (*request.Request, *ec2.DisassociateEnclaveCertificateIamRoleOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisassociateEnclaveCertificateIamRoleRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateEnclaveCertificateIamRoleOutput)
+	return ret0, ret1
+}
+
+// DisassociateEnclaveCertificateIamRoleRequest indicates an expected call of DisassociateEnclaveCertificateIamRoleRequest
+func (mr *MockEC2APIMockRecorder) DisassociateEnclaveCertificateIamRoleRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateEnclaveCertificateIamRoleRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateEnclaveCertificateIamRoleRequest), arg0)
+}
+
+// DisassociateEnclaveCertificateIamRoleWithContext mocks base method
+func (m *MockEC2API) DisassociateEnclaveCertificateIamRoleWithContext(arg0 context.Context, arg1 *ec2.DisassociateEnclaveCertificateIamRoleInput, arg2 ...request.Option) (*ec2.DisassociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DisassociateEnclaveCertificateIamRoleWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DisassociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateEnclaveCertificateIamRoleWithContext indicates an expected call of DisassociateEnclaveCertificateIamRoleWithContext
+func (mr *MockEC2APIMockRecorder) DisassociateEnclaveCertificateIamRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateEnclaveCertificateIamRoleWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateEnclaveCertificateIamRoleWithContext), varargs...)
+}
+
 // DisassociateIamInstanceProfile mocks base method
 func (m *MockEC2API) DisassociateIamInstanceProfile(arg0 *ec2.DisassociateIamInstanceProfileInput) (*ec2.DisassociateIamInstanceProfileOutput, error) {
 	m.ctrl.T.Helper()
@@ -17523,6 +17623,56 @@ func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutesWithContext(arg0, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutesWithContext), varargs...)
+}
+
+// GetAssociatedEnclaveCertificateIamRoles mocks base method
+func (m *MockEC2API) GetAssociatedEnclaveCertificateIamRoles(arg0 *ec2.GetAssociatedEnclaveCertificateIamRolesInput) (*ec2.GetAssociatedEnclaveCertificateIamRolesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssociatedEnclaveCertificateIamRoles", arg0)
+	ret0, _ := ret[0].(*ec2.GetAssociatedEnclaveCertificateIamRolesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssociatedEnclaveCertificateIamRoles indicates an expected call of GetAssociatedEnclaveCertificateIamRoles
+func (mr *MockEC2APIMockRecorder) GetAssociatedEnclaveCertificateIamRoles(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssociatedEnclaveCertificateIamRoles", reflect.TypeOf((*MockEC2API)(nil).GetAssociatedEnclaveCertificateIamRoles), arg0)
+}
+
+// GetAssociatedEnclaveCertificateIamRolesRequest mocks base method
+func (m *MockEC2API) GetAssociatedEnclaveCertificateIamRolesRequest(arg0 *ec2.GetAssociatedEnclaveCertificateIamRolesInput) (*request.Request, *ec2.GetAssociatedEnclaveCertificateIamRolesOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssociatedEnclaveCertificateIamRolesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetAssociatedEnclaveCertificateIamRolesOutput)
+	return ret0, ret1
+}
+
+// GetAssociatedEnclaveCertificateIamRolesRequest indicates an expected call of GetAssociatedEnclaveCertificateIamRolesRequest
+func (mr *MockEC2APIMockRecorder) GetAssociatedEnclaveCertificateIamRolesRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssociatedEnclaveCertificateIamRolesRequest", reflect.TypeOf((*MockEC2API)(nil).GetAssociatedEnclaveCertificateIamRolesRequest), arg0)
+}
+
+// GetAssociatedEnclaveCertificateIamRolesWithContext mocks base method
+func (m *MockEC2API) GetAssociatedEnclaveCertificateIamRolesWithContext(arg0 context.Context, arg1 *ec2.GetAssociatedEnclaveCertificateIamRolesInput, arg2 ...request.Option) (*ec2.GetAssociatedEnclaveCertificateIamRolesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetAssociatedEnclaveCertificateIamRolesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.GetAssociatedEnclaveCertificateIamRolesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssociatedEnclaveCertificateIamRolesWithContext indicates an expected call of GetAssociatedEnclaveCertificateIamRolesWithContext
+func (mr *MockEC2APIMockRecorder) GetAssociatedEnclaveCertificateIamRolesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssociatedEnclaveCertificateIamRolesWithContext", reflect.TypeOf((*MockEC2API)(nil).GetAssociatedEnclaveCertificateIamRolesWithContext), varargs...)
 }
 
 // GetAssociatedIpv6PoolCidrs mocks base method

--- a/aws/mock/elasticache.go
+++ b/aws/mock/elasticache.go
@@ -685,6 +685,106 @@ func (mr *MockElastiCacheAPIMockRecorder) CreateSnapshotWithContext(arg0, arg1 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSnapshotWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).CreateSnapshotWithContext), varargs...)
 }
 
+// CreateUser mocks base method
+func (m *MockElastiCacheAPI) CreateUser(arg0 *elasticache.CreateUserInput) (*elasticache.CreateUserOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUser", arg0)
+	ret0, _ := ret[0].(*elasticache.CreateUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUser indicates an expected call of CreateUser
+func (mr *MockElastiCacheAPIMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockElastiCacheAPI)(nil).CreateUser), arg0)
+}
+
+// CreateUserGroup mocks base method
+func (m *MockElastiCacheAPI) CreateUserGroup(arg0 *elasticache.CreateUserGroupInput) (*elasticache.CreateUserGroupOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUserGroup", arg0)
+	ret0, _ := ret[0].(*elasticache.CreateUserGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUserGroup indicates an expected call of CreateUserGroup
+func (mr *MockElastiCacheAPIMockRecorder) CreateUserGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserGroup", reflect.TypeOf((*MockElastiCacheAPI)(nil).CreateUserGroup), arg0)
+}
+
+// CreateUserGroupRequest mocks base method
+func (m *MockElastiCacheAPI) CreateUserGroupRequest(arg0 *elasticache.CreateUserGroupInput) (*request.Request, *elasticache.CreateUserGroupOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUserGroupRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateUserGroupOutput)
+	return ret0, ret1
+}
+
+// CreateUserGroupRequest indicates an expected call of CreateUserGroupRequest
+func (mr *MockElastiCacheAPIMockRecorder) CreateUserGroupRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserGroupRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).CreateUserGroupRequest), arg0)
+}
+
+// CreateUserGroupWithContext mocks base method
+func (m *MockElastiCacheAPI) CreateUserGroupWithContext(arg0 context.Context, arg1 *elasticache.CreateUserGroupInput, arg2 ...request.Option) (*elasticache.CreateUserGroupOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateUserGroupWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.CreateUserGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUserGroupWithContext indicates an expected call of CreateUserGroupWithContext
+func (mr *MockElastiCacheAPIMockRecorder) CreateUserGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserGroupWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).CreateUserGroupWithContext), varargs...)
+}
+
+// CreateUserRequest mocks base method
+func (m *MockElastiCacheAPI) CreateUserRequest(arg0 *elasticache.CreateUserInput) (*request.Request, *elasticache.CreateUserOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUserRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateUserOutput)
+	return ret0, ret1
+}
+
+// CreateUserRequest indicates an expected call of CreateUserRequest
+func (mr *MockElastiCacheAPIMockRecorder) CreateUserRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).CreateUserRequest), arg0)
+}
+
+// CreateUserWithContext mocks base method
+func (m *MockElastiCacheAPI) CreateUserWithContext(arg0 context.Context, arg1 *elasticache.CreateUserInput, arg2 ...request.Option) (*elasticache.CreateUserOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateUserWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.CreateUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateUserWithContext indicates an expected call of CreateUserWithContext
+func (mr *MockElastiCacheAPIMockRecorder) CreateUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).CreateUserWithContext), varargs...)
+}
+
 // DecreaseNodeGroupsInGlobalReplicationGroup mocks base method
 func (m *MockElastiCacheAPI) DecreaseNodeGroupsInGlobalReplicationGroup(arg0 *elasticache.DecreaseNodeGroupsInGlobalReplicationGroupInput) (*elasticache.DecreaseNodeGroupsInGlobalReplicationGroupOutput, error) {
 	m.ctrl.T.Helper()
@@ -1133,6 +1233,106 @@ func (mr *MockElastiCacheAPIMockRecorder) DeleteSnapshotWithContext(arg0, arg1 i
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSnapshotWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DeleteSnapshotWithContext), varargs...)
+}
+
+// DeleteUser mocks base method
+func (m *MockElastiCacheAPI) DeleteUser(arg0 *elasticache.DeleteUserInput) (*elasticache.DeleteUserOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUser", arg0)
+	ret0, _ := ret[0].(*elasticache.DeleteUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUser indicates an expected call of DeleteUser
+func (mr *MockElastiCacheAPIMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockElastiCacheAPI)(nil).DeleteUser), arg0)
+}
+
+// DeleteUserGroup mocks base method
+func (m *MockElastiCacheAPI) DeleteUserGroup(arg0 *elasticache.DeleteUserGroupInput) (*elasticache.DeleteUserGroupOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserGroup", arg0)
+	ret0, _ := ret[0].(*elasticache.DeleteUserGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUserGroup indicates an expected call of DeleteUserGroup
+func (mr *MockElastiCacheAPIMockRecorder) DeleteUserGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserGroup", reflect.TypeOf((*MockElastiCacheAPI)(nil).DeleteUserGroup), arg0)
+}
+
+// DeleteUserGroupRequest mocks base method
+func (m *MockElastiCacheAPI) DeleteUserGroupRequest(arg0 *elasticache.DeleteUserGroupInput) (*request.Request, *elasticache.DeleteUserGroupOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserGroupRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteUserGroupOutput)
+	return ret0, ret1
+}
+
+// DeleteUserGroupRequest indicates an expected call of DeleteUserGroupRequest
+func (mr *MockElastiCacheAPIMockRecorder) DeleteUserGroupRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserGroupRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).DeleteUserGroupRequest), arg0)
+}
+
+// DeleteUserGroupWithContext mocks base method
+func (m *MockElastiCacheAPI) DeleteUserGroupWithContext(arg0 context.Context, arg1 *elasticache.DeleteUserGroupInput, arg2 ...request.Option) (*elasticache.DeleteUserGroupOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteUserGroupWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.DeleteUserGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUserGroupWithContext indicates an expected call of DeleteUserGroupWithContext
+func (mr *MockElastiCacheAPIMockRecorder) DeleteUserGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserGroupWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DeleteUserGroupWithContext), varargs...)
+}
+
+// DeleteUserRequest mocks base method
+func (m *MockElastiCacheAPI) DeleteUserRequest(arg0 *elasticache.DeleteUserInput) (*request.Request, *elasticache.DeleteUserOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteUserOutput)
+	return ret0, ret1
+}
+
+// DeleteUserRequest indicates an expected call of DeleteUserRequest
+func (mr *MockElastiCacheAPIMockRecorder) DeleteUserRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).DeleteUserRequest), arg0)
+}
+
+// DeleteUserWithContext mocks base method
+func (m *MockElastiCacheAPI) DeleteUserWithContext(arg0 context.Context, arg1 *elasticache.DeleteUserInput, arg2 ...request.Option) (*elasticache.DeleteUserOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteUserWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.DeleteUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUserWithContext indicates an expected call of DeleteUserWithContext
+func (mr *MockElastiCacheAPIMockRecorder) DeleteUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DeleteUserWithContext), varargs...)
 }
 
 // DescribeCacheClusters mocks base method
@@ -2380,6 +2580,172 @@ func (mr *MockElastiCacheAPIMockRecorder) DescribeUpdateActionsWithContext(arg0,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUpdateActionsWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUpdateActionsWithContext), varargs...)
 }
 
+// DescribeUserGroups mocks base method
+func (m *MockElastiCacheAPI) DescribeUserGroups(arg0 *elasticache.DescribeUserGroupsInput) (*elasticache.DescribeUserGroupsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeUserGroups", arg0)
+	ret0, _ := ret[0].(*elasticache.DescribeUserGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeUserGroups indicates an expected call of DescribeUserGroups
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUserGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUserGroups", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUserGroups), arg0)
+}
+
+// DescribeUserGroupsPages mocks base method
+func (m *MockElastiCacheAPI) DescribeUserGroupsPages(arg0 *elasticache.DescribeUserGroupsInput, arg1 func(*elasticache.DescribeUserGroupsOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeUserGroupsPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeUserGroupsPages indicates an expected call of DescribeUserGroupsPages
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUserGroupsPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUserGroupsPages", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUserGroupsPages), arg0, arg1)
+}
+
+// DescribeUserGroupsPagesWithContext mocks base method
+func (m *MockElastiCacheAPI) DescribeUserGroupsPagesWithContext(arg0 context.Context, arg1 *elasticache.DescribeUserGroupsInput, arg2 func(*elasticache.DescribeUserGroupsOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeUserGroupsPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeUserGroupsPagesWithContext indicates an expected call of DescribeUserGroupsPagesWithContext
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUserGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUserGroupsPagesWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUserGroupsPagesWithContext), varargs...)
+}
+
+// DescribeUserGroupsRequest mocks base method
+func (m *MockElastiCacheAPI) DescribeUserGroupsRequest(arg0 *elasticache.DescribeUserGroupsInput) (*request.Request, *elasticache.DescribeUserGroupsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeUserGroupsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeUserGroupsOutput)
+	return ret0, ret1
+}
+
+// DescribeUserGroupsRequest indicates an expected call of DescribeUserGroupsRequest
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUserGroupsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUserGroupsRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUserGroupsRequest), arg0)
+}
+
+// DescribeUserGroupsWithContext mocks base method
+func (m *MockElastiCacheAPI) DescribeUserGroupsWithContext(arg0 context.Context, arg1 *elasticache.DescribeUserGroupsInput, arg2 ...request.Option) (*elasticache.DescribeUserGroupsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeUserGroupsWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.DescribeUserGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeUserGroupsWithContext indicates an expected call of DescribeUserGroupsWithContext
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUserGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUserGroupsWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUserGroupsWithContext), varargs...)
+}
+
+// DescribeUsers mocks base method
+func (m *MockElastiCacheAPI) DescribeUsers(arg0 *elasticache.DescribeUsersInput) (*elasticache.DescribeUsersOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeUsers", arg0)
+	ret0, _ := ret[0].(*elasticache.DescribeUsersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeUsers indicates an expected call of DescribeUsers
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUsers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUsers", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUsers), arg0)
+}
+
+// DescribeUsersPages mocks base method
+func (m *MockElastiCacheAPI) DescribeUsersPages(arg0 *elasticache.DescribeUsersInput, arg1 func(*elasticache.DescribeUsersOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeUsersPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeUsersPages indicates an expected call of DescribeUsersPages
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUsersPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUsersPages", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUsersPages), arg0, arg1)
+}
+
+// DescribeUsersPagesWithContext mocks base method
+func (m *MockElastiCacheAPI) DescribeUsersPagesWithContext(arg0 context.Context, arg1 *elasticache.DescribeUsersInput, arg2 func(*elasticache.DescribeUsersOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeUsersPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeUsersPagesWithContext indicates an expected call of DescribeUsersPagesWithContext
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUsersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUsersPagesWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUsersPagesWithContext), varargs...)
+}
+
+// DescribeUsersRequest mocks base method
+func (m *MockElastiCacheAPI) DescribeUsersRequest(arg0 *elasticache.DescribeUsersInput) (*request.Request, *elasticache.DescribeUsersOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeUsersRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeUsersOutput)
+	return ret0, ret1
+}
+
+// DescribeUsersRequest indicates an expected call of DescribeUsersRequest
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUsersRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUsersRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUsersRequest), arg0)
+}
+
+// DescribeUsersWithContext mocks base method
+func (m *MockElastiCacheAPI) DescribeUsersWithContext(arg0 context.Context, arg1 *elasticache.DescribeUsersInput, arg2 ...request.Option) (*elasticache.DescribeUsersOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeUsersWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.DescribeUsersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeUsersWithContext indicates an expected call of DescribeUsersWithContext
+func (mr *MockElastiCacheAPIMockRecorder) DescribeUsersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUsersWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).DescribeUsersWithContext), varargs...)
+}
+
 // DisassociateGlobalReplicationGroup mocks base method
 func (m *MockElastiCacheAPI) DisassociateGlobalReplicationGroup(arg0 *elasticache.DisassociateGlobalReplicationGroupInput) (*elasticache.DisassociateGlobalReplicationGroupOutput, error) {
 	m.ctrl.T.Helper()
@@ -2978,6 +3344,106 @@ func (mr *MockElastiCacheAPIMockRecorder) ModifyReplicationGroupWithContext(arg0
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyReplicationGroupWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).ModifyReplicationGroupWithContext), varargs...)
+}
+
+// ModifyUser mocks base method
+func (m *MockElastiCacheAPI) ModifyUser(arg0 *elasticache.ModifyUserInput) (*elasticache.ModifyUserOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyUser", arg0)
+	ret0, _ := ret[0].(*elasticache.ModifyUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyUser indicates an expected call of ModifyUser
+func (mr *MockElastiCacheAPIMockRecorder) ModifyUser(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyUser", reflect.TypeOf((*MockElastiCacheAPI)(nil).ModifyUser), arg0)
+}
+
+// ModifyUserGroup mocks base method
+func (m *MockElastiCacheAPI) ModifyUserGroup(arg0 *elasticache.ModifyUserGroupInput) (*elasticache.ModifyUserGroupOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyUserGroup", arg0)
+	ret0, _ := ret[0].(*elasticache.ModifyUserGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyUserGroup indicates an expected call of ModifyUserGroup
+func (mr *MockElastiCacheAPIMockRecorder) ModifyUserGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyUserGroup", reflect.TypeOf((*MockElastiCacheAPI)(nil).ModifyUserGroup), arg0)
+}
+
+// ModifyUserGroupRequest mocks base method
+func (m *MockElastiCacheAPI) ModifyUserGroupRequest(arg0 *elasticache.ModifyUserGroupInput) (*request.Request, *elasticache.ModifyUserGroupOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyUserGroupRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.ModifyUserGroupOutput)
+	return ret0, ret1
+}
+
+// ModifyUserGroupRequest indicates an expected call of ModifyUserGroupRequest
+func (mr *MockElastiCacheAPIMockRecorder) ModifyUserGroupRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyUserGroupRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).ModifyUserGroupRequest), arg0)
+}
+
+// ModifyUserGroupWithContext mocks base method
+func (m *MockElastiCacheAPI) ModifyUserGroupWithContext(arg0 context.Context, arg1 *elasticache.ModifyUserGroupInput, arg2 ...request.Option) (*elasticache.ModifyUserGroupOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyUserGroupWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.ModifyUserGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyUserGroupWithContext indicates an expected call of ModifyUserGroupWithContext
+func (mr *MockElastiCacheAPIMockRecorder) ModifyUserGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyUserGroupWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).ModifyUserGroupWithContext), varargs...)
+}
+
+// ModifyUserRequest mocks base method
+func (m *MockElastiCacheAPI) ModifyUserRequest(arg0 *elasticache.ModifyUserInput) (*request.Request, *elasticache.ModifyUserOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyUserRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.ModifyUserOutput)
+	return ret0, ret1
+}
+
+// ModifyUserRequest indicates an expected call of ModifyUserRequest
+func (mr *MockElastiCacheAPIMockRecorder) ModifyUserRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyUserRequest", reflect.TypeOf((*MockElastiCacheAPI)(nil).ModifyUserRequest), arg0)
+}
+
+// ModifyUserWithContext mocks base method
+func (m *MockElastiCacheAPI) ModifyUserWithContext(arg0 context.Context, arg1 *elasticache.ModifyUserInput, arg2 ...request.Option) (*elasticache.ModifyUserOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyUserWithContext", varargs...)
+	ret0, _ := ret[0].(*elasticache.ModifyUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyUserWithContext indicates an expected call of ModifyUserWithContext
+func (mr *MockElastiCacheAPIMockRecorder) ModifyUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyUserWithContext", reflect.TypeOf((*MockElastiCacheAPI)(nil).ModifyUserWithContext), varargs...)
 }
 
 // PurchaseReservedCacheNodesOffering mocks base method

--- a/rules/api/aws_instance_invalid_ami.go
+++ b/rules/api/aws_instance_invalid_ami.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"fmt"
+	"log"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
+)
+
+// AwsInstanceInvalidAMIRule checks whether "aws_instance" has invalid AMI ID
+type AwsInstanceInvalidAMIRule struct {
+	resourceType  string
+	attributeName string
+	amiIDs        map[string]bool
+}
+
+// NewAwsInstanceInvalidAMIRule returns new rule with default attributes
+func NewAwsInstanceInvalidAMIRule() *AwsInstanceInvalidAMIRule {
+	return &AwsInstanceInvalidAMIRule{
+		resourceType:  "aws_instance",
+		attributeName: "ami",
+		amiIDs:        map[string]bool{},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceInvalidAMIRule) Name() string {
+	return "aws_instance_invalid_ami"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceInvalidAMIRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsInstanceInvalidAMIRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsInstanceInvalidAMIRule) Link() string {
+	return ""
+}
+
+// Check checks whether "aws_instance" has invalid AMI ID
+func (r *AwsInstanceInvalidAMIRule) Check(rr tflint.Runner) error {
+	runner := rr.(*aws.Runner)
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var ami string
+		err := runner.EvaluateExpr(attribute.Expr, &ami, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.amiIDs[ami] {
+				log.Printf("[DEBUG] Fetch AMI images: %s", ami)
+				resp, err := runner.AwsClient.EC2.DescribeImages(&ec2.DescribeImagesInput{
+					ImageIds: awssdk.StringSlice([]string{ami}),
+				})
+				if err != nil {
+					if aerr, ok := err.(awserr.Error); ok {
+						switch aerr.Code() {
+						case "InvalidAMIID.Malformed":
+							fallthrough
+						case "InvalidAMIID.NotFound":
+							fallthrough
+						case "InvalidAMIID.Unavailable":
+							runner.EmitIssueOnExpr(
+								r,
+								fmt.Sprintf("\"%s\" is invalid AMI ID.", ami),
+								attribute.Expr,
+							)
+							return nil
+						}
+					}
+					err := &tflint.Error{
+						Code:    tflint.ExternalAPIError,
+						Level:   tflint.ErrorLevel,
+						Message: "An error occurred while describing images",
+						Cause:   err,
+					}
+					log.Printf("[ERROR] %s", err)
+					return err
+				}
+
+				if len(resp.Images) != 0 {
+					for _, image := range resp.Images {
+						r.amiIDs[*image.ImageId] = true
+					}
+				} else {
+					runner.EmitIssueOnExpr(
+						r,
+						fmt.Sprintf("\"%s\" is invalid AMI ID.", ami),
+						attribute.Expr,
+					)
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/api/aws_instance_invalid_ami_test.go
+++ b/rules/api/aws_instance_invalid_ami_test.go
@@ -1,0 +1,262 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws/mock"
+)
+
+func Test_AwsInstanceInvalidAMI_invalid(t *testing.T) {
+	content := `
+resource "aws_instance" "invalid" {
+	ami = "ami-1234abcd"
+}`
+	runner := NewTestRunner(t, map[string]string{"instances.tf": content})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2mock := mock.NewMockEC2API(ctrl)
+	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: aws.StringSlice([]string{"ami-1234abcd"}),
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{},
+	}, nil)
+	runner.AwsClient.EC2 = ec2mock
+
+	rule := NewAwsInstanceInvalidAMIRule()
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	expected := helper.Issues{
+		{
+			Rule:    NewAwsInstanceInvalidAMIRule(),
+			Message: "\"ami-1234abcd\" is invalid AMI ID.",
+			Range: hcl.Range{
+				Filename: "instances.tf",
+				Start:    hcl.Pos{Line: 3, Column: 8},
+				End:      hcl.Pos{Line: 3, Column: 22},
+			},
+		},
+	}
+	helper.AssertIssues(t, expected, runner.Runner.(*helper.Runner).Issues)
+}
+
+func Test_AwsInstanceInvalidAMI_valid(t *testing.T) {
+	content := `
+resource "aws_instance" "valid" {
+	ami = "ami-9ad76sd1"
+}`
+	runner := NewTestRunner(t, map[string]string{"instances.tf": content})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2mock := mock.NewMockEC2API(ctrl)
+	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{
+			{
+				ImageId: aws.String("ami-9ad76sd1"),
+			},
+		},
+	}, nil)
+	runner.AwsClient.EC2 = ec2mock
+
+	rule := NewAwsInstanceInvalidAMIRule()
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	expected := helper.Issues{}
+	helper.AssertIssues(t, expected, runner.Runner.(*helper.Runner).Issues)
+}
+
+func Test_AwsInstanceInvalidAMI_error(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Request  *ec2.DescribeImagesInput
+		Response error
+		Error    tflint.Error
+	}{
+		{
+			Name: "AWS API error",
+			Content: `
+resource "aws_instance" "valid" {
+  ami = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"MissingRegion",
+				"could not find region configuration",
+				nil,
+			),
+			Error: tflint.Error{
+				Code:    tflint.ExternalAPIError,
+				Level:   tflint.ErrorLevel,
+				Message: "An error occurred while describing images; MissingRegion: could not find region configuration",
+			},
+		},
+		{
+			Name: "Unexpected error",
+			Content: `
+resource "aws_instance" "valid" {
+  ami = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: errors.New("Unexpected"),
+			Error: tflint.Error{
+				Code:    tflint.ExternalAPIError,
+				Level:   tflint.ErrorLevel,
+				Message: "An error occurred while describing images; Unexpected",
+			},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rule := NewAwsInstanceInvalidAMIRule()
+
+	for _, tc := range cases {
+		runner := NewTestRunner(t, map[string]string{"instances.tf": tc.Content})
+
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = ec2mock
+
+		err := rule.Check(runner)
+		AssertAppError(t, tc.Error, err)
+	}
+}
+
+func Test_AwsInstanceInvalidAMI_AMIError(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Request  *ec2.DescribeImagesInput
+		Response error
+		Issues   helper.Issues
+		Error    bool
+	}{
+		{
+			Name: "not found",
+			Content: `
+resource "aws_instance" "not_found" {
+	ami = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.NotFound",
+				"The image id '[ami-9ad76sd1]' does not exist",
+				nil,
+			),
+			Issues: helper.Issues{
+				{
+					Rule:    NewAwsInstanceInvalidAMIRule(),
+					Message: "\"ami-9ad76sd1\" is invalid AMI ID.",
+					Range: hcl.Range{
+						Filename: "instances.tf",
+						Start:    hcl.Pos{Line: 3, Column: 8},
+						End:      hcl.Pos{Line: 3, Column: 22},
+					},
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "malformed",
+			Content: `
+resource "aws_instance" "malformed" {
+	ami = "image-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"image-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Malformed",
+				"Invalid id: \"image-9ad76sd1\" (expecting \"ami-...\")",
+				nil,
+			),
+			Issues: helper.Issues{
+				{
+					Rule:    NewAwsInstanceInvalidAMIRule(),
+					Message: "\"image-9ad76sd1\" is invalid AMI ID.",
+					Range: hcl.Range{
+						Filename: "instances.tf",
+						Start:    hcl.Pos{Line: 3, Column: 8},
+						End:      hcl.Pos{Line: 3, Column: 24},
+					},
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "unavailable",
+			Content: `
+resource "aws_instance" "unavailable" {
+	ami = "ami-1234567"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-1234567"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Unavailable",
+				"The image ID: 'ami-1234567' is no longer available",
+				nil,
+			),
+			Issues: helper.Issues{
+				{
+					Rule:    NewAwsInstanceInvalidAMIRule(),
+					Message: "\"ami-1234567\" is invalid AMI ID.",
+					Range: hcl.Range{
+						Filename: "instances.tf",
+						Start:    hcl.Pos{Line: 3, Column: 8},
+						End:      hcl.Pos{Line: 3, Column: 21},
+					},
+				},
+			},
+			Error: false,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rule := NewAwsInstanceInvalidAMIRule()
+
+	for _, tc := range cases {
+		runner := NewTestRunner(t, map[string]string{"instances.tf": tc.Content})
+
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = ec2mock
+
+		err := rule.Check(runner)
+		if err != nil && !tc.Error {
+			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+		if err == nil && tc.Error {
+			t.Fatalf("Failed `%s` test: expected to return an error, but nothing occurred", tc.Name)
+		}
+
+		helper.AssertIssues(t, tc.Issues, runner.Runner.(*helper.Runner).Issues)
+	}
+}

--- a/rules/api/aws_launch_configuration_invalid_image_id.go
+++ b/rules/api/aws_launch_configuration_invalid_image_id.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"fmt"
+	"log"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
+)
+
+// AwsLaunchConfigurationInvalidImageIDRule checks whether "aws_instance" has invalid AMI ID
+type AwsLaunchConfigurationInvalidImageIDRule struct {
+	resourceType  string
+	attributeName string
+	amiIDs        map[string]bool
+}
+
+// NewAwsLaunchConfigurationInvalidImageIDRule returns new rule with default attributes
+func NewAwsLaunchConfigurationInvalidImageIDRule() *AwsLaunchConfigurationInvalidImageIDRule {
+	return &AwsLaunchConfigurationInvalidImageIDRule{
+		resourceType:  "aws_launch_configuration",
+		attributeName: "image_id",
+		amiIDs:        map[string]bool{},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsLaunchConfigurationInvalidImageIDRule) Name() string {
+	return "aws_launch_configuration_invalid_image_id"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsLaunchConfigurationInvalidImageIDRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsLaunchConfigurationInvalidImageIDRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsLaunchConfigurationInvalidImageIDRule) Link() string {
+	return ""
+}
+
+// Check checks whether "aws_instance" has invalid AMI ID
+func (r *AwsLaunchConfigurationInvalidImageIDRule) Check(rr tflint.Runner) error {
+	runner := rr.(*aws.Runner)
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var ami string
+		err := runner.EvaluateExpr(attribute.Expr, &ami, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.amiIDs[ami] {
+				log.Printf("[DEBUG] Fetch AMI images: %s", ami)
+				resp, err := runner.AwsClient.EC2.DescribeImages(&ec2.DescribeImagesInput{
+					ImageIds: awssdk.StringSlice([]string{ami}),
+				})
+				if err != nil {
+					if aerr, ok := err.(awserr.Error); ok {
+						switch aerr.Code() {
+						case "InvalidAMIID.Malformed":
+							fallthrough
+						case "InvalidAMIID.NotFound":
+							fallthrough
+						case "InvalidAMIID.Unavailable":
+							runner.EmitIssueOnExpr(
+								r,
+								fmt.Sprintf("\"%s\" is invalid image ID.", ami),
+								attribute.Expr,
+							)
+							return nil
+						}
+					}
+					err := &tflint.Error{
+						Code:    tflint.ExternalAPIError,
+						Level:   tflint.ErrorLevel,
+						Message: "An error occurred while describing images",
+						Cause:   err,
+					}
+					log.Printf("[ERROR] %s", err)
+					return err
+				}
+
+				if len(resp.Images) != 0 {
+					for _, image := range resp.Images {
+						r.amiIDs[*image.ImageId] = true
+					}
+				} else {
+					runner.EmitIssueOnExpr(
+						r,
+						fmt.Sprintf("\"%s\" is invalid image ID.", ami),
+						attribute.Expr,
+					)
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/api/aws_launch_configuration_invalid_image_id_test.go
+++ b/rules/api/aws_launch_configuration_invalid_image_id_test.go
@@ -1,0 +1,263 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws/mock"
+)
+
+func Test_AwsLaunchConfigurationInvalidImageID_invalid(t *testing.T) {
+	content := `
+resource "aws_launch_configuration" "invalid" {
+	image_id = "ami-1234abcd"
+}`
+	runner := NewTestRunner(t, map[string]string{"instances.tf": content})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2mock := mock.NewMockEC2API(ctrl)
+	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: aws.StringSlice([]string{"ami-1234abcd"}),
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{},
+	}, nil)
+	runner.AwsClient.EC2 = ec2mock
+
+	rule := NewAwsLaunchConfigurationInvalidImageIDRule()
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	expected := helper.Issues{
+		{
+			Rule:    NewAwsLaunchConfigurationInvalidImageIDRule(),
+			Message: "\"ami-1234abcd\" is invalid image ID.",
+			Range: hcl.Range{
+				Filename: "instances.tf",
+				Start:    hcl.Pos{Line: 3, Column: 13},
+				End:      hcl.Pos{Line: 3, Column: 27},
+			},
+		},
+	}
+
+	helper.AssertIssues(t, expected, runner.Runner.(*helper.Runner).Issues)
+}
+
+func Test_AwsLaunchConfigurationInvalidImageID_valid(t *testing.T) {
+	content := `
+resource "aws_launch_configuration" "valid" {
+	image_id = "ami-9ad76sd1"
+}`
+	runner := NewTestRunner(t, map[string]string{"instances.tf": content})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2mock := mock.NewMockEC2API(ctrl)
+	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{
+			{
+				ImageId: aws.String("ami-9ad76sd1"),
+			},
+		},
+	}, nil)
+	runner.AwsClient.EC2 = ec2mock
+
+	rule := NewAwsLaunchConfigurationInvalidImageIDRule()
+	if err := rule.Check(runner); err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	expected := helper.Issues{}
+	helper.AssertIssues(t, expected, runner.Runner.(*helper.Runner).Issues)
+}
+
+func Test_AwsLaunchConfigurationInvalidImageID_error(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Request  *ec2.DescribeImagesInput
+		Response error
+		Error    tflint.Error
+	}{
+		{
+			Name: "AWS API error",
+			Content: `
+resource "aws_launch_configuration" "valid" {
+  image_id = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"MissingRegion",
+				"could not find region configuration",
+				nil,
+			),
+			Error: tflint.Error{
+				Code:    tflint.ExternalAPIError,
+				Level:   tflint.ErrorLevel,
+				Message: "An error occurred while describing images; MissingRegion: could not find region configuration",
+			},
+		},
+		{
+			Name: "Unexpected error",
+			Content: `
+resource "aws_launch_configuration" "valid" {
+	image_id = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: errors.New("Unexpected"),
+			Error: tflint.Error{
+				Code:    tflint.ExternalAPIError,
+				Level:   tflint.ErrorLevel,
+				Message: "An error occurred while describing images; Unexpected",
+			},
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rule := NewAwsLaunchConfigurationInvalidImageIDRule()
+
+	for _, tc := range cases {
+		runner := NewTestRunner(t, map[string]string{"instances.tf": tc.Content})
+
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = ec2mock
+
+		err := rule.Check(runner)
+		AssertAppError(t, tc.Error, err)
+	}
+}
+
+func Test_AwsLaunchConfigurationInvalidImageID_AMIError(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Request  *ec2.DescribeImagesInput
+		Response error
+		Issues   helper.Issues
+		Error    bool
+	}{
+		{
+			Name: "not found",
+			Content: `
+resource "aws_launch_configuration" "not_found" {
+	image_id = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.NotFound",
+				"The image id '[ami-9ad76sd1]' does not exist",
+				nil,
+			),
+			Issues: helper.Issues{
+				{
+					Rule:    NewAwsLaunchConfigurationInvalidImageIDRule(),
+					Message: "\"ami-9ad76sd1\" is invalid image ID.",
+					Range: hcl.Range{
+						Filename: "instances.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13},
+						End:      hcl.Pos{Line: 3, Column: 27},
+					},
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "malformed",
+			Content: `
+resource "aws_launch_configuration" "malformed" {
+	image_id = "image-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"image-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Malformed",
+				"Invalid id: \"image-9ad76sd1\" (expecting \"ami-...\")",
+				nil,
+			),
+			Issues: helper.Issues{
+				{
+					Rule:    NewAwsLaunchConfigurationInvalidImageIDRule(),
+					Message: "\"image-9ad76sd1\" is invalid image ID.",
+					Range: hcl.Range{
+						Filename: "instances.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13},
+						End:      hcl.Pos{Line: 3, Column: 29},
+					},
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "unavailable",
+			Content: `
+resource "aws_launch_configuration" "unavailable" {
+	image_id = "ami-1234567"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-1234567"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Unavailable",
+				"The image ID: 'ami-1234567' is no longer available",
+				nil,
+			),
+			Issues: helper.Issues{
+				{
+					Rule:    NewAwsLaunchConfigurationInvalidImageIDRule(),
+					Message: "\"ami-1234567\" is invalid image ID.",
+					Range: hcl.Range{
+						Filename: "instances.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13},
+						End:      hcl.Pos{Line: 3, Column: 26},
+					},
+				},
+			},
+			Error: false,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rule := NewAwsLaunchConfigurationInvalidImageIDRule()
+
+	for _, tc := range cases {
+		runner := NewTestRunner(t, map[string]string{"instances.tf": tc.Content})
+
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = ec2mock
+
+		err := rule.Check(runner)
+		if err != nil && !tc.Error {
+			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+		if err == nil && tc.Error {
+			t.Fatalf("Failed `%s` test: expected to return an error, but nothing occurred", tc.Name)
+		}
+
+		helper.AssertIssues(t, tc.Issues, runner.Runner.(*helper.Runner).Issues)
+	}
+}

--- a/rules/api/provider.go
+++ b/rules/api/provider.go
@@ -6,6 +6,8 @@ import "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 
 // Rules is a list of rules with invoking APIs
 var Rules = []tflint.Rule{
+	NewAwsInstanceInvalidAMIRule(),
+	NewAwsLaunchConfigurationInvalidImageIDRule(),
 	NewAwsALBInvalidSecurityGroupRule(),
 	NewAwsALBInvalidSubnetRule(),
 	NewAwsDBInstanceInvalidDBSubnetGroupRule(),

--- a/rules/api/provider.go.tmpl
+++ b/rules/api/provider.go.tmpl
@@ -6,6 +6,8 @@ import "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 
 // Rules is a list of rules with invoking APIs
 var Rules = []tflint.Rule{
+	NewAwsInstanceInvalidAMIRule(),
+	NewAwsLaunchConfigurationInvalidImageIDRule(),
 	{{- range $v := .RuleNameCCList }}
 	New{{ $v }}Rule(),
 	{{- end }}

--- a/rules/aws_db_instance_default_parameter_group.go
+++ b/rules/aws_db_instance_default_parameter_group.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsDBInstanceDefaultParameterGroupRule checks whether the db instance use default parameter group
+type AwsDBInstanceDefaultParameterGroupRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsDBInstanceDefaultParameterGroupRule returns new rule with default attributes
+func NewAwsDBInstanceDefaultParameterGroupRule() *AwsDBInstanceDefaultParameterGroupRule {
+	return &AwsDBInstanceDefaultParameterGroupRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "parameter_group_name",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceDefaultParameterGroupRule) Name() string {
+	return "aws_db_instance_default_parameter_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceDefaultParameterGroupRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsDBInstanceDefaultParameterGroupRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *AwsDBInstanceDefaultParameterGroupRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+var defaultDBParameterGroupRegexp = regexp.MustCompile("^default")
+
+// Check checks the parameter group name starts with `default`
+func (r *AwsDBInstanceDefaultParameterGroupRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var name string
+		err := runner.EvaluateExpr(attribute.Expr, &name, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if defaultDBParameterGroupRegexp.Match([]byte(name)) {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", name),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_db_instance_default_parameter_group_test.go
+++ b/rules/aws_db_instance_default_parameter_group_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsDBInstanceDefaultParameterGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "default.mysql5.6 is default parameter group",
+			Content: `
+resource "aws_db_instance" "db" {
+    parameter_group_name = "default.mysql5.6"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsDBInstanceDefaultParameterGroupRule(),
+					Message: "\"default.mysql5.6\" is default parameter group. You cannot edit it.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 28},
+						End:      hcl.Pos{Line: 3, Column: 46},
+					},
+				},
+			},
+		},
+		{
+			Name: "application5.6 is not default parameter group",
+			Content: `
+resource "aws_db_instance" "db" {
+    parameter_group_name = "application5.6"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsDBInstanceDefaultParameterGroupRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_db_instance_invalid_type.go
+++ b/rules/aws_db_instance_invalid_type.go
@@ -1,0 +1,171 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsDBInstanceInvalidTypeRule checks whether "aws_db_instance" has invalid intance type.
+type AwsDBInstanceInvalidTypeRule struct {
+	resourceType  string
+	attributeName string
+	instanceTypes map[string]bool
+}
+
+// NewAwsDBInstanceInvalidTypeRule returns new rule with default attributes
+func NewAwsDBInstanceInvalidTypeRule() *AwsDBInstanceInvalidTypeRule {
+	return &AwsDBInstanceInvalidTypeRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "instance_class",
+		instanceTypes: map[string]bool{
+			"db.cr1.8xlarge":   true,
+			"db.cv11.18xlarge": true,
+			"db.cv11.2xlarge":  true,
+			"db.cv11.4xlarge":  true,
+			"db.cv11.9xlarge":  true,
+			"db.cv11.large":    true,
+			"db.cv11.medium":   true,
+			"db.cv11.small":    true,
+			"db.cv11.xlarge":   true,
+			"db.m1.large":      true,
+			"db.m1.medium":     true,
+			"db.m1.small":      true,
+			"db.m1.xlarge":     true,
+			"db.m2.2xlarge":    true,
+			"db.m2.4xlarge":    true,
+			"db.m2.xlarge":     true,
+			"db.m3.2xlarge":    true,
+			"db.m3.large":      true,
+			"db.m3.medium":     true,
+			"db.m3.xlarge":     true,
+			"db.m4.10xlarge":   true,
+			"db.m4.16xlarge":   true,
+			"db.m4.2xlarge":    true,
+			"db.m4.4xlarge":    true,
+			"db.m4.large":      true,
+			"db.m4.xlarge":     true,
+			"db.m5.12xlarge":   true,
+			"db.m5.16xlarge":   true,
+			"db.m5.24xlarge":   true,
+			"db.m5.2xlarge":    true,
+			"db.m5.4xlarge":    true,
+			"db.m5.8xlarge":    true,
+			"db.m5.large":      true,
+			"db.m5.xlarge":     true,
+			"db.m6g.16xlarge":  true,
+			"db.m6g.12xlarge":  true,
+			"db.m6g.8xlarge":   true,
+			"db.m6g.4xlarge":   true,
+			"db.m6g.2xlarge":   true,
+			"db.m6g.xlarge":    true,
+			"db.m6g.large":     true,
+			"db.mv11.12xlarge": true,
+			"db.mv11.24xlarge": true,
+			"db.mv11.2xlarge":  true,
+			"db.mv11.4xlarge":  true,
+			"db.mv11.large":    true,
+			"db.mv11.medium":   true,
+			"db.mv11.xlarge":   true,
+			"db.r3.2xlarge":    true,
+			"db.r3.4xlarge":    true,
+			"db.r3.8xlarge":    true,
+			"db.r3.large":      true,
+			"db.r3.xlarge":     true,
+			"db.r4.16xlarge":   true,
+			"db.r4.2xlarge":    true,
+			"db.r4.4xlarge":    true,
+			"db.r4.8xlarge":    true,
+			"db.r4.large":      true,
+			"db.r4.xlarge":     true,
+			"db.r5.12xlarge":   true,
+			"db.r5.16xlarge":   true,
+			"db.r5.24xlarge":   true,
+			"db.r5.2xlarge":    true,
+			"db.r5.4xlarge":    true,
+			"db.r5.8xlarge":    true,
+			"db.r5.large":      true,
+			"db.r5.xlarge":     true,
+			"db.r6g.16xlarge":  true,
+			"db.r6g.12xlarge":  true,
+			"db.r6g.4xlarge":   true,
+			"db.r6g.2xlarge":   true,
+			"db.r6g.xlarge":    true,
+			"db.r6g.large":     true,
+			"db.rv11.12xlarge": true,
+			"db.rv11.24xlarge": true,
+			"db.rv11.2xlarge":  true,
+			"db.rv11.4xlarge":  true,
+			"db.rv11.large":    true,
+			"db.rv11.xlarge":   true,
+			"db.t1.micro":      true,
+			"db.t2.2xlarge":    true,
+			"db.t2.large":      true,
+			"db.t2.medium":     true,
+			"db.t2.micro":      true,
+			"db.t2.small":      true,
+			"db.t2.xlarge":     true,
+			"db.t3.2xlarge":    true,
+			"db.t3.large":      true,
+			"db.t3.medium":     true,
+			"db.t3.micro":      true,
+			"db.t3.small":      true,
+			"db.t3.xlarge":     true,
+			"db.x1.16xlarge":   true,
+			"db.x1.32xlarge":   true,
+			"db.x1e.16xlarge":  true,
+			"db.x1e.2xlarge":   true,
+			"db.x1e.32xlarge":  true,
+			"db.x1e.4xlarge":   true,
+			"db.x1e.8xlarge":   true,
+			"db.x1e.xlarge":    true,
+			"db.z1d.12xlarge":  true,
+			"db.z1d.2xlarge":   true,
+			"db.z1d.3xlarge":   true,
+			"db.z1d.6xlarge":   true,
+			"db.z1d.large":     true,
+			"db.z1d.xlarge":    true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceInvalidTypeRule) Name() string {
+	return "aws_db_instance_invalid_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceInvalidTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsDBInstanceInvalidTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsDBInstanceInvalidTypeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether "aws_db_instance" has invalid instance type.
+func (r *AwsDBInstanceInvalidTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var instanceType string
+		err := runner.EvaluateExpr(attribute.Expr, &instanceType, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.instanceTypes[instanceType] {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is invalid instance type.", instanceType),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_db_instance_invalid_type_test.go
+++ b/rules/aws_db_instance_invalid_type_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsDBInstanceInvalidType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "m4.2xlarge is invalid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "m4.2xlarge"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsDBInstanceInvalidTypeRule(),
+					Message: "\"m4.2xlarge\" is invalid instance type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 22},
+						End:      hcl.Pos{Line: 3, Column: 34},
+					},
+				},
+			},
+		},
+		{
+			Name: "db.m4.2xlarge is valid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "db.m4.2xlarge"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsDBInstanceInvalidTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_db_instance_previous_type.go
+++ b/rules/aws_db_instance_previous_type.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsDBInstancePreviousTypeRule checks whether the resource uses previous generation instance type
+type AwsDBInstancePreviousTypeRule struct {
+	resourceType          string
+	attributeName         string
+	previousInstanceTypes map[string]bool
+}
+
+// NewAwsDBInstancePreviousTypeRule returns new rule with default attributes
+func NewAwsDBInstancePreviousTypeRule() *AwsDBInstancePreviousTypeRule {
+	return &AwsDBInstancePreviousTypeRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "instance_class",
+		previousInstanceTypes: map[string]bool{
+			"db.t1.micro":    true,
+			"db.m1.small":    true,
+			"db.m1.medium":   true,
+			"db.m1.large":    true,
+			"db.m1.xlarge":   true,
+			"db.m2.xlarge":   true,
+			"db.m2.2xlarge":  true,
+			"db.m2.4xlarge":  true,
+			"db.m3.medium":   true,
+			"db.m3.large":    true,
+			"db.m3.xlarge":   true,
+			"db.m3.2xlarge":  true,
+			"db.r3.large":    true,
+			"db.r3.xlarge":   true,
+			"db.r3.2xlarge":  true,
+			"db.r3.4xlarge":  true,
+			"db.r3.8xlarge":  true,
+			"db.cr1.8xlarge": true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstancePreviousTypeRule) Name() string {
+	return "aws_db_instance_previous_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstancePreviousTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsDBInstancePreviousTypeRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsDBInstancePreviousTypeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether the resource's `instance_class` is included in the list of previous generation instance type
+func (r *AwsDBInstancePreviousTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var instanceType string
+		err := runner.EvaluateExpr(attribute.Expr, &instanceType, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if r.previousInstanceTypes[instanceType] {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_db_instance_previous_type_test.go
+++ b/rules/aws_db_instance_previous_type_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsDBInstancePreviousType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "db.t1.micro is previous type",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "db.t1.micro"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsDBInstancePreviousTypeRule(),
+					Message: "\"db.t1.micro\" is previous generation instance type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 22},
+						End:      hcl.Pos{Line: 3, Column: 35},
+					},
+				},
+			},
+		},
+		{
+			Name: "db.t2.micro is not previous type",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "db.t2.micro"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsDBInstancePreviousTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_dynamodb_table_invalid_stream_view_type.go
+++ b/rules/aws_dynamodb_table_invalid_stream_view_type.go
@@ -1,0 +1,75 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsDynamoDBTableInvalidStreamViewTypeRule checks the pattern is valid
+type AwsDynamoDBTableInvalidStreamViewTypeRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// NewAwsDynamoDBTableInvalidStreamViewTypeRule returns new rule with default attributes
+func NewAwsDynamoDBTableInvalidStreamViewTypeRule() *AwsDynamoDBTableInvalidStreamViewTypeRule {
+	return &AwsDynamoDBTableInvalidStreamViewTypeRule{
+		resourceType:  "aws_dynamodb_table",
+		attributeName: "stream_view_type",
+		enum: []string{
+			"",
+			"NEW_IMAGE",
+			"OLD_IMAGE",
+			"NEW_AND_OLD_IMAGES",
+			"KEYS_ONLY",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDynamoDBTableInvalidStreamViewTypeRule) Name() string {
+	return "aws_dynamodb_table_invalid_stream_view_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDynamoDBTableInvalidStreamViewTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsDynamoDBTableInvalidStreamViewTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsDynamoDBTableInvalidStreamViewTypeRule) Link() string {
+	return ""
+}
+
+// Check checks the pattern is valid
+func (r *AwsDynamoDBTableInvalidStreamViewTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			for _, item := range r.enum {
+				if item == val {
+					found = true
+				}
+			}
+			if !found {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" is an invalid value as stream_view_type`, val),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_dynamodb_table_invalid_stream_view_type_test.go
+++ b/rules/aws_dynamodb_table_invalid_stream_view_type_test.go
@@ -1,0 +1,57 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsDynamoDBTableInvalidStreamViewTypeRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "It includes invalid characters",
+			Content: `
+resource "aws_dynamodb_table" "foo" {
+	stream_view_type = "OLD_AND_NEW_IMAGE"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsDynamoDBTableInvalidStreamViewTypeRule(),
+					Message: `"OLD_AND_NEW_IMAGE" is an invalid value as stream_view_type`,
+				},
+			},
+		},
+		{
+			Name: "It is valid",
+			Content: `
+resource "aws_dynamodb_table" "foo" {
+	stream_view_type = "NEW_IMAGE"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "empty string",
+			Content: `
+resource "aws_dynamodb_table" "foo" {
+	stream_view_type = ""
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsDynamoDBTableInvalidStreamViewTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_elasticache_cluster_default_parameter_group.go
+++ b/rules/aws_elasticache_cluster_default_parameter_group.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsElastiCacheClusterDefaultParameterGroupRule checks whether the cluster use default parameter group
+type AwsElastiCacheClusterDefaultParameterGroupRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsElastiCacheClusterDefaultParameterGroupRule returns new rule with default attributes
+func NewAwsElastiCacheClusterDefaultParameterGroupRule() *AwsElastiCacheClusterDefaultParameterGroupRule {
+	return &AwsElastiCacheClusterDefaultParameterGroupRule{
+		resourceType:  "aws_elasticache_cluster",
+		attributeName: "parameter_group_name",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Name() string {
+	return "aws_elasticache_cluster_default_parameter_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+var defaultElastiCacheParameterGroupRegexp = regexp.MustCompile("^default")
+
+// Check checks the parameter group name starts with `default`
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var parameterGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &parameterGroup, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if defaultElastiCacheParameterGroupRegexp.Match([]byte(parameterGroup)) {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/rules/aws_elasticache_cluster_default_parameter_group_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsElastiCacheClusterDefaultParameterGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "default.redis3.2 is default parameter group",
+			Content: `
+resource "aws_elasticache_cluster" "cache" {
+    parameter_group_name = "default.redis3.2"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsElastiCacheClusterDefaultParameterGroupRule(),
+					Message: "\"default.redis3.2\" is default parameter group. You cannot edit it.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 28},
+						End:      hcl.Pos{Line: 3, Column: 46},
+					},
+				},
+			},
+		},
+		{
+			Name: "application3.2 is not default parameter group",
+			Content: `
+resource "aws_elasticache_cluster" "cache" {
+    parameter_group_name = "application3.2"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsElastiCacheClusterDefaultParameterGroupRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_elasticache_cluster_invalid_type.go
+++ b/rules/aws_elasticache_cluster_invalid_type.go
@@ -1,0 +1,126 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsElastiCacheClusterInvalidTypeRule checks whether "aws_elasticache_cluster" has invalid node type.
+type AwsElastiCacheClusterInvalidTypeRule struct {
+	resourceType  string
+	attributeName string
+	nodeTypes     map[string]bool
+}
+
+// NewAwsElastiCacheClusterInvalidTypeRule returns new rule with default attributes
+func NewAwsElastiCacheClusterInvalidTypeRule() *AwsElastiCacheClusterInvalidTypeRule {
+	return &AwsElastiCacheClusterInvalidTypeRule{
+		resourceType:  "aws_elasticache_cluster",
+		attributeName: "node_type",
+		nodeTypes: map[string]bool{
+			"cache.t2.micro":     true,
+			"cache.t2.small":     true,
+			"cache.t2.medium":    true,
+			"cache.t3.micro":     true,
+			"cache.t3.small":     true,
+			"cache.t3.medium":    true,
+			"cache.m3.medium":    true,
+			"cache.m3.large":     true,
+			"cache.m3.xlarge":    true,
+			"cache.m3.2xlarge":   true,
+			"cache.m4.large":     true,
+			"cache.m4.xlarge":    true,
+			"cache.m4.2xlarge":   true,
+			"cache.m4.4xlarge":   true,
+			"cache.m4.10xlarge":  true,
+			"cache.m5.large":     true,
+			"cache.m5.xlarge":    true,
+			"cache.m5.2xlarge":   true,
+			"cache.m5.4xlarge":   true,
+			"cache.m5.12xlarge":  true,
+			"cache.m5.24xlarge":  true,
+			"cache.m6g.large":    true,
+			"cache.m6g.xlarge":   true,
+			"cache.m6g.2xlarge":  true,
+			"cache.m6g.4xlarge":  true,
+			"cache.m6g.8xlarge":  true,
+			"cache.m6g.12xlarge": true,
+			"cache.m6g.16xlarge": true,
+			"cache.r3.large":     true,
+			"cache.r3.xlarge":    true,
+			"cache.r3.2xlarge":   true,
+			"cache.r3.4xlarge":   true,
+			"cache.r3.8xlarge":   true,
+			"cache.r4.large":     true,
+			"cache.r4.xlarge":    true,
+			"cache.r4.2xlarge":   true,
+			"cache.r4.4xlarge":   true,
+			"cache.r4.8xlarge":   true,
+			"cache.r4.16xlarge":  true,
+			"cache.r5.large":     true,
+			"cache.r5.xlarge":    true,
+			"cache.r5.2xlarge":   true,
+			"cache.r5.4xlarge":   true,
+			"cache.r5.12xlarge":  true,
+			"cache.r5.24xlarge":  true,
+			"cache.r6g.large":    true,
+			"cache.r6g.xlarge":   true,
+			"cache.r6g.2xlarge":  true,
+			"cache.r6g.4xlarge":  true,
+			"cache.r6g.8xlarge":  true,
+			"cache.r6g.12xlarge": true,
+			"cache.r6g.16xlarge": true,
+			"cache.m1.small":     true,
+			"cache.m1.medium":    true,
+			"cache.m1.large":     true,
+			"cache.m1.xlarge":    true,
+			"cache.m2.xlarge":    true,
+			"cache.m2.2xlarge":   true,
+			"cache.m2.4xlarge":   true,
+			"cache.c1.xlarge":    true,
+			"cache.t1.micro":     true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterInvalidTypeRule) Name() string {
+	return "aws_elasticache_cluster_invalid_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterInvalidTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsElastiCacheClusterInvalidTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsElastiCacheClusterInvalidTypeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether "aws_elasticache_cluster" has invalid node type.
+func (r *AwsElastiCacheClusterInvalidTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var nodeType string
+		err := runner.EvaluateExpr(attribute.Expr, &nodeType, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.nodeTypes[nodeType] {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is invalid node type.", nodeType),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_elasticache_cluster_invalid_type_test.go
+++ b/rules/aws_elasticache_cluster_invalid_type_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsElastiCacheClusterInvalidType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "t2.micro is invalid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "t2.micro"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsElastiCacheClusterInvalidTypeRule(),
+					Message: "\"t2.micro\" is invalid node type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 17},
+						End:      hcl.Pos{Line: 3, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "cache.t2.micro is valid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "cache.t2.micro"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsElastiCacheClusterInvalidTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_elasticache_cluster_previous_type.go
+++ b/rules/aws_elasticache_cluster_previous_type.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsElastiCacheClusterPreviousTypeRule checks whether the resource uses previous generation node type
+type AwsElastiCacheClusterPreviousTypeRule struct {
+	resourceType      string
+	attributeName     string
+	previousNodeTypes map[string]bool
+}
+
+// NewAwsElastiCacheClusterPreviousTypeRule returns new rule with default attributes
+func NewAwsElastiCacheClusterPreviousTypeRule() *AwsElastiCacheClusterPreviousTypeRule {
+	return &AwsElastiCacheClusterPreviousTypeRule{
+		resourceType:  "aws_elasticache_cluster",
+		attributeName: "node_type",
+		previousNodeTypes: map[string]bool{
+			"cache.m1.small":   true,
+			"cache.m1.medium":  true,
+			"cache.m1.large":   true,
+			"cache.m1.xlarge":  true,
+			"cache.m2.xlarge":  true,
+			"cache.m2.2xlarge": true,
+			"cache.m2.4xlarge": true,
+			"cache.m3.medium":  true,
+			"cache.m3.large":   true,
+			"cache.m3.xlarge":  true,
+			"cache.m3.2xlarge": true,
+			"cache.r3.large":   true,
+			"cache.r3.xlarge":  true,
+			"cache.r3.2xlarge": true,
+			"cache.r3.4xlarge": true,
+			"cache.r3.8xlarge": true,
+			"cache.c1.xlarge":  true,
+			"cache.t1.micro":   true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterPreviousTypeRule) Name() string {
+	return "aws_elasticache_cluster_previous_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterPreviousTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsElastiCacheClusterPreviousTypeRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsElastiCacheClusterPreviousTypeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether the resource's `node_type` is included in the list of previous generation node type
+func (r *AwsElastiCacheClusterPreviousTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var nodeType string
+		err := runner.EvaluateExpr(attribute.Expr, &nodeType, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if r.previousNodeTypes[nodeType] {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),
+					attribute.Expr.Range(),
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_elasticache_cluster_previous_type_test.go
+++ b/rules/aws_elasticache_cluster_previous_type_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsElastiCacheClusterPreviousType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "cache.t1.micro is previous type",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "cache.t1.micro"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsElastiCacheClusterPreviousTypeRule(),
+					Message: "\"cache.t1.micro\" is previous generation node type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 17},
+						End:      hcl.Pos{Line: 3, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			Name: "cache.t2.micro is not previous type",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "cache.t2.micro"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsElastiCacheClusterPreviousTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_instance_previous_type.go
+++ b/rules/aws_instance_previous_type.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsInstancePreviousTypeRule checks whether the resource uses previous generation instance type
+type AwsInstancePreviousTypeRule struct {
+	resourceType          string
+	attributeName         string
+	previousInstanceTypes map[string]bool
+}
+
+// NewAwsInstancePreviousTypeRule returns new rule with default attributes
+func NewAwsInstancePreviousTypeRule() *AwsInstancePreviousTypeRule {
+	return &AwsInstancePreviousTypeRule{
+		resourceType:  "aws_instance",
+		attributeName: "instance_type",
+		previousInstanceTypes: map[string]bool{
+			"t1.micro":    true,
+			"m1.small":    true,
+			"m1.medium":   true,
+			"m1.large":    true,
+			"m1.xlarge":   true,
+			"m3.medium":   true,
+			"m3.large":    true,
+			"m3.xlarge":   true,
+			"m3.2xlarge":  true,
+			"c1.medium":   true,
+			"c1.xlarge":   true,
+			"cc2.8xlarge": true,
+			"cg1.4xlarge": true,
+			"c3.large":    true,
+			"c3.xlarge":   true,
+			"c3.2xlarge":  true,
+			"c3.4xlarge":  true,
+			"c3.8xlarge":  true,
+			"g2.2xlarge":  true,
+			"g2.8xlarge":  true,
+			"m2.xlarge":   true,
+			"m2.2xlarge":  true,
+			"m2.4xlarge":  true,
+			"cr1.8xlarge": true,
+			"r3.large":    true,
+			"r3.xlarge":   true,
+			"r3.2xlarge":  true,
+			"r3.4xlarge":  true,
+			"r3.8xlarge":  true,
+			"i2.xlarge":   true,
+			"i2.2xlarge":  true,
+			"i2.4xlarge":  true,
+			"i2.8xlarge":  true,
+			"hi1.4xlarge": true,
+			"hs1.8xlarge": true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstancePreviousTypeRule) Name() string {
+	return "aws_instance_previous_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstancePreviousTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsInstancePreviousTypeRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsInstancePreviousTypeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether the resource's `instance_type` is included in the list of previous generation instance type
+func (r *AwsInstancePreviousTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var instanceType string
+		err := runner.EvaluateExpr(attribute.Expr, &instanceType, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if r.previousInstanceTypes[instanceType] {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_instance_previous_type_test.go
+++ b/rules/aws_instance_previous_type_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsInstancePreviousType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "t1.micro is previous type",
+			Content: `
+resource "aws_instance" "web" {
+    instance_type = "t1.micro"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsInstancePreviousTypeRule(),
+					Message: "\"t1.micro\" is previous generation instance type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 21},
+						End:      hcl.Pos{Line: 3, Column: 31},
+					},
+				},
+			},
+		},
+		{
+			Name: "t2.micro is not previous type",
+			Content: `
+resource "aws_instance" "web" {
+    instance_type = "t2.micro"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsInstancePreviousTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_mq_broker_invalid_engine_type.go
+++ b/rules/aws_mq_broker_invalid_engine_type.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsMqBrokerInvalidEngineTypeRule checks the pattern is valid
+type AwsMqBrokerInvalidEngineTypeRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// NewAwsMqBrokerInvalidEngineTypeRule returns new rule with default attributes
+func NewAwsMqBrokerInvalidEngineTypeRule() *AwsMqBrokerInvalidEngineTypeRule {
+	return &AwsMqBrokerInvalidEngineTypeRule{
+		resourceType:  "aws_mq_broker",
+		attributeName: "engine_type",
+		enum: []string{
+			"ActiveMQ",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsMqBrokerInvalidEngineTypeRule) Name() string {
+	return "aws_mq_broker_invalid_engine_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsMqBrokerInvalidEngineTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsMqBrokerInvalidEngineTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsMqBrokerInvalidEngineTypeRule) Link() string {
+	return ""
+}
+
+// Check checks the pattern is valid
+func (r *AwsMqBrokerInvalidEngineTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			for _, item := range r.enum {
+				if item == val {
+					found = true
+				}
+			}
+			if !found {
+				runner.EmitIssueOnExpr(
+					r,
+					`engine_type is not a valid value`,
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_mq_configuration_invalid_engine_type.go
+++ b/rules/aws_mq_configuration_invalid_engine_type.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsMqConfigurationInvalidEngineTypeRule checks the pattern is valid
+type AwsMqConfigurationInvalidEngineTypeRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// NewAwsMqConfigurationInvalidEngineTypeRule returns new rule with default attributes
+func NewAwsMqConfigurationInvalidEngineTypeRule() *AwsMqConfigurationInvalidEngineTypeRule {
+	return &AwsMqConfigurationInvalidEngineTypeRule{
+		resourceType:  "aws_mq_configuration",
+		attributeName: "engine_type",
+		enum: []string{
+			"ActiveMQ",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsMqConfigurationInvalidEngineTypeRule) Name() string {
+	return "aws_mq_configuration_invalid_engine_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsMqConfigurationInvalidEngineTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsMqConfigurationInvalidEngineTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsMqConfigurationInvalidEngineTypeRule) Link() string {
+	return ""
+}
+
+// Check checks the pattern is valid
+func (r *AwsMqConfigurationInvalidEngineTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			for _, item := range r.enum {
+				if item == val {
+					found = true
+				}
+			}
+			if !found {
+				runner.EmitIssueOnExpr(
+					r,
+					`engine_type is not a valid value`,
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_s3_bucket_invalid_acl.go
+++ b/rules/aws_s3_bucket_invalid_acl.go
@@ -1,0 +1,78 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsS3BucketInvalidACLRule checks the pattern is valid
+type AwsS3BucketInvalidACLRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// NewAwsS3BucketInvalidACLRule returns new rule with default attributes
+func NewAwsS3BucketInvalidACLRule() *AwsS3BucketInvalidACLRule {
+	return &AwsS3BucketInvalidACLRule{
+		resourceType:  "aws_s3_bucket",
+		attributeName: "acl",
+		enum: []string{
+			"private",
+			"public-read",
+			"public-read-write",
+			"aws-exec-read",
+			"authenticated-read",
+			"log-delivery-write",
+			"bucket-owner-read",
+			"bucket-owner-full-control",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsS3BucketInvalidACLRule) Name() string {
+	return "aws_s3_bucket_invalid_acl"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsS3BucketInvalidACLRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsS3BucketInvalidACLRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsS3BucketInvalidACLRule) Link() string {
+	return ""
+}
+
+// Check checks the pattern is valid
+func (r *AwsS3BucketInvalidACLRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			for _, item := range r.enum {
+				if item == val {
+					found = true
+				}
+			}
+			if !found {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" is an invalid value as acl`, val),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_s3_bucket_invalid_region.go
+++ b/rules/aws_s3_bucket_invalid_region.go
@@ -1,0 +1,92 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsS3BucketInvalidRegionRule checks the pattern is valid
+type AwsS3BucketInvalidRegionRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// NewAwsS3BucketInvalidRegionRule returns new rule with default attributes
+func NewAwsS3BucketInvalidRegionRule() *AwsS3BucketInvalidRegionRule {
+	return &AwsS3BucketInvalidRegionRule{
+		resourceType:  "aws_s3_bucket",
+		attributeName: "region",
+		enum: []string{
+			"EU",
+			"us-east-1",
+			"us-east-2",
+			"eu-west-1",
+			"eu-west-2",
+			"eu-west-3",
+			"eu-north-1",
+			"us-west-1",
+			"us-west-2",
+			"ap-east-1",
+			"ap-south-1",
+			"ap-southeast-1",
+			"ap-southeast-2",
+			"ap-northeast-1",
+			"ap-northeast-2",
+			"ap-northeast-3",
+			"ca-central-1",
+			"sa-east-1",
+			"cn-north-1",
+			"cn-northwest-1",
+			"eu-central-1",
+			"me-south-1",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsS3BucketInvalidRegionRule) Name() string {
+	return "aws_s3_bucket_invalid_region"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsS3BucketInvalidRegionRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsS3BucketInvalidRegionRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsS3BucketInvalidRegionRule) Link() string {
+	return ""
+}
+
+// Check checks the pattern is valid
+func (r *AwsS3BucketInvalidRegionRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			for _, item := range r.enum {
+				if item == val {
+					found = true
+				}
+			}
+			if !found {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" is an invalid value as region`, val),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_s3_bucket_name.go
+++ b/rules/aws_s3_bucket_name.go
@@ -1,0 +1,92 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsS3BucketNameRule checks that an S3 bucket name matches naming rules
+type AwsS3BucketNameRule struct {
+	resourceType  string
+	attributeName string
+}
+
+type awsS3BucketNameConfig struct {
+	Regex  string `hcl:"regex,optional"`
+	Prefix string `hcl:"prefix,optional"`
+}
+
+// NewAwsS3BucketNameRule returns a new rule with default attributes
+func NewAwsS3BucketNameRule() *AwsS3BucketNameRule {
+	return &AwsS3BucketNameRule{
+		resourceType:  "aws_s3_bucket",
+		attributeName: "bucket",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsS3BucketNameRule) Name() string {
+	return "aws_s3_bucket_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsS3BucketNameRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *AwsS3BucketNameRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsS3BucketNameRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check if the name of the s3 bucket matches the regex defined in the rule
+func (r *AwsS3BucketNameRule) Check(runner tflint.Runner) error {
+	config := awsS3BucketNameConfig{}
+	if err := runner.DecodeRuleConfig(r.Name(), &config); err != nil {
+		return err
+	}
+
+	regex, err := regexp.Compile(config.Regex)
+	if err != nil {
+		return fmt.Errorf("invalid regex (%s): %w", config.Regex, err)
+	}
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var name string
+		err := runner.EvaluateExpr(attribute.Expr, &name, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if config.Prefix != "" {
+				if !strings.HasPrefix(name, config.Prefix) {
+					runner.EmitIssue(
+						r,
+						fmt.Sprintf(`Bucket name "%s" does not have prefix "%s"`, name, config.Prefix),
+						attribute.Expr.Range(),
+					)
+				}
+			}
+
+			if config.Regex != "" {
+				if !regex.MatchString(name) {
+					runner.EmitIssue(
+						r,
+						fmt.Sprintf(`Bucket name "%s" does not match regex "%s"`, name, config.Regex),
+						attribute.Expr.Range(),
+					)
+				}
+			}
+
+			return nil
+		})
+	})
+}

--- a/rules/aws_s3_bucket_name_test.go
+++ b/rules/aws_s3_bucket_name_test.go
@@ -1,0 +1,140 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsS3BucketName(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Config   string
+		Expected helper.Issues
+		Error    bool
+	}{
+		{
+			Name: "regex",
+			Content: `
+resource "aws_s3_bucket" "foo" {
+  bucket = "foo-bucket"
+}
+
+resource "aws_s3_bucket" "bar" {
+	bucket = "bar-bucket"
+}`,
+			Config: `
+rule "aws_s3_bucket_name" {
+	enabled = true
+	regex = "^foo"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket name "bar-bucket" does not match regex "^foo"`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 7, Column: 11},
+						End:      hcl.Pos{Line: 7, Column: 23},
+					},
+				},
+			},
+		},
+		{
+			Name:    "invalid regex",
+			Content: ``,
+			Config: `
+rule "aws_s3_bucket_name" {
+	enabled = true
+	regex = "\\"
+}`,
+			Expected: helper.Issues{},
+			Error:    true,
+		},
+		{
+			Name: "prefix",
+			Content: `
+resource "aws_s3_bucket" "foo" {
+  bucket = "foo-bar"
+}
+
+resource "aws_s3_bucket" "bar" {
+	bucket = "bar-baz"
+}`,
+			Config: `
+rule "aws_s3_bucket_name" {
+	enabled = true
+	prefix = "foo-"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket name "bar-baz" does not have prefix "foo-"`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 7, Column: 11},
+						End:      hcl.Pos{Line: 7, Column: 20},
+					},
+				},
+			},
+		},
+		{
+			Name: "regex and prefix",
+			Content: `
+resource "aws_s3_bucket" "foo" {
+  bucket = "foo-bar"
+}
+
+resource "aws_s3_bucket" "bar" {
+	bucket = "bar-baz"
+}`,
+			Config: `
+rule "aws_s3_bucket_name" {
+	enabled = true
+	prefix = "foo-"
+	regex = "^f"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket name "bar-baz" does not have prefix "foo-"`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 7, Column: 11},
+						End:      hcl.Pos{Line: 7, Column: 20},
+					},
+				},
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket name "bar-baz" does not match regex "^f"`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 7, Column: 11},
+						End:      hcl.Pos{Line: 7, Column: 20},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsS3BucketNameRule()
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content, ".tflint.hcl": tc.Config})
+
+			err := rule.Check(runner)
+			if err != nil && !tc.Error {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+			if err == nil && tc.Error {
+				t.Fatal("Expected error but got none")
+			}
+
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/aws_spot_fleet_request_invalid_excess_capacity_termination_policy.go
+++ b/rules/aws_spot_fleet_request_invalid_excess_capacity_termination_policy.go
@@ -1,0 +1,72 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule checks the pattern is valid
+type AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule returns new rule with default attributes
+func NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule() *AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule {
+	return &AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule{
+		resourceType:  "aws_spot_fleet_request",
+		attributeName: "excess_capacity_termination_policy",
+		enum: []string{
+			"Default",
+			"NoTermination",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule) Name() string {
+	return "aws_spot_fleet_request_invalid_excess_capacity_termination_policy"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule) Link() string {
+	return ""
+}
+
+// Check checks the pattern is valid
+func (r *AwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			for _, item := range r.enum {
+				if item == val {
+					found = true
+				}
+			}
+			if !found {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" is an invalid value as excess_capacity_termination_policy`, val),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -7,6 +7,20 @@ import (
 
 // Rules is a list of all rules
 var Rules = append([]tflint.Rule{
-	NewAwsInstanceExampleTypeRule(),
+	NewAwsDBInstanceDefaultParameterGroupRule(),
+	NewAwsDBInstanceInvalidTypeRule(),
+	NewAwsDBInstancePreviousTypeRule(),
+	NewAwsDynamoDBTableInvalidStreamViewTypeRule(),
+	NewAwsElastiCacheClusterDefaultParameterGroupRule(),
+	NewAwsElastiCacheClusterInvalidTypeRule(),
+	NewAwsElastiCacheClusterPreviousTypeRule(),
+	NewAwsInstancePreviousTypeRule(),
+	NewAwsMqBrokerInvalidEngineTypeRule(),
+	NewAwsMqConfigurationInvalidEngineTypeRule(),
 	NewAwsResourceMissingTagsRule(),
+	NewAwsS3BucketInvalidACLRule(),
+	NewAwsS3BucketInvalidRegionRule(),
+	NewAwsS3BucketNameRule(),
+	NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
+	NewAwsInstanceExampleTypeRule(),
 }, models.Rules...)


### PR DESCRIPTION
Migrate the rules except for `aws_route_not_specified_target` and `aws_route_specified_multiple_targets_rule` to this plugin.

These two rules depend on `IsNullExpr` and will be migrated after implementing this in the SDK.