### PR TITLE
Migrate the aws_route rules from TFLint core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo v1.14.2 // indirect
 	github.com/onsi/gomega v1.10.3 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e
-	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9
+	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201219154003-09b2270d9de5
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9
 	github.com/zclconf/go-cty v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9 h1:ADqZANXUwQzsBtG4nuaz8qGjXsetvHgk67Fr2OmRJs4=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201219154003-09b2270d9de5 h1:PCwAYfajRygdxp9gtEu6SDfbN9jm2X/TjDgetlf9fck=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201219154003-09b2270d9de5/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9 h1:0u9SqTq2nbof0t+7xqfI8Ejhmooe3Qqe09fobOCZY6g=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9/go.mod h1:sToOUnPCXFPwMljH57zM6uOI3q1YVREy4GSlg1Wm8/Y=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/rules/aws_route_not_specified_target.go
+++ b/rules/aws_route_not_specified_target.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsRouteNotSpecifiedTargetRule checks whether a route definition has a routing target
+type AwsRouteNotSpecifiedTargetRule struct {
+	resourceType string
+}
+
+// NewAwsRouteNotSpecifiedTargetRule returns new rule with default attributes
+func NewAwsRouteNotSpecifiedTargetRule() *AwsRouteNotSpecifiedTargetRule {
+	return &AwsRouteNotSpecifiedTargetRule{
+		resourceType: "aws_route",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteNotSpecifiedTargetRule) Name() string {
+	return "aws_route_not_specified_target"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteNotSpecifiedTargetRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsRouteNotSpecifiedTargetRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsRouteNotSpecifiedTargetRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether `gateway_id`, `egress_only_gateway_id`, `nat_gateway_id`, `instance_id`
+// `vpc_peering_connection_id`, `network_interface_id` or `vpc_endpoint_id`  is defined in a resource
+func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
+	return runner.WalkResources(r.resourceType, func(resource *configs.Resource) error {
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: "gateway_id",
+				},
+				{
+					Name: "egress_only_gateway_id",
+				},
+				{
+					Name: "nat_gateway_id",
+				},
+				{
+					Name: "instance_id",
+				},
+				{
+					Name: "vpc_peering_connection_id",
+				},
+				{
+					Name: "network_interface_id",
+				},
+				{
+					Name: "transit_gateway_id",
+				},
+				{
+					Name: "vpc_endpoint_id",
+				},
+			},
+		})
+		if diags.HasErrors() {
+			return diags
+		}
+
+		var nullAttributes int
+		for _, attribute := range body.Attributes {
+			isNull, err := runner.IsNullExpr(attribute.Expr)
+			if err != nil {
+				return err
+			}
+
+			if isNull {
+				nullAttributes = nullAttributes + 1
+			}
+		}
+
+		if len(body.Attributes)-nullAttributes == 0 {
+			runner.EmitIssue(
+				r,
+				"The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id or vpc_endpoint_id.",
+				resource.DeclRange,
+			)
+		}
+
+		return nil
+	})
+}

--- a/rules/aws_route_not_specified_target_test.go
+++ b/rules/aws_route_not_specified_target_test.go
@@ -1,0 +1,138 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsRouteNotSpecifiedTarget(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "route target is not specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsRouteNotSpecifiedTargetRule(),
+					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id or vpc_endpoint_id.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "gateway_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "egress_only_gateway_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    egress_only_gateway_id = "eigw-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "nat_gateway_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    nat_gateway_id = "nat-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "instance_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    instance_id = "i-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "vpc_peering_connection_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    vpc_peering_connection_id = "pcx-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "network_interface_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    network_interface_id = "eni-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "transit_gateway_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+	route_table_id = "rtb-1234abcd"
+	transit_gateway_id = "tgw-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "transit_gateway_id is specified, but the value is null",
+			Content: `
+resource "aws_route" "foo" {
+	route_table_id = "rtb-1234abcd"
+	transit_gateway_id = null
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsRouteNotSpecifiedTargetRule(),
+					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id or vpc_endpoint_id.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "vpc_endpoint_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+	route_table_id = "rtb-1234abcd"
+	vpc_endpoint_id = "vpce-12345678abcdefgh"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsRouteNotSpecifiedTargetRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_route_specified_multiple_targets.go
+++ b/rules/aws_route_specified_multiple_targets.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsRouteSpecifiedMultipleTargetsRule checks whether a route definition has multiple routing targets
+type AwsRouteSpecifiedMultipleTargetsRule struct {
+	resourceType string
+}
+
+// NewAwsRouteSpecifiedMultipleTargetsRule returns new rule with default attributes
+func NewAwsRouteSpecifiedMultipleTargetsRule() *AwsRouteSpecifiedMultipleTargetsRule {
+	return &AwsRouteSpecifiedMultipleTargetsRule{
+		resourceType: "aws_route",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Name() string {
+	return "aws_route_specified_multiple_targets"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether a resource defines `gateway_id`, `egress_only_gateway_id`, `nat_gateway_id`
+// `instance_id`, `vpc_peering_connection_id` or `network_interface_id` at the same time
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner tflint.Runner) error {
+	return runner.WalkResources(r.resourceType, func(resource *configs.Resource) error {
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: "gateway_id",
+				},
+				{
+					Name: "egress_only_gateway_id",
+				},
+				{
+					Name: "nat_gateway_id",
+				},
+				{
+					Name: "instance_id",
+				},
+				{
+					Name: "vpc_peering_connection_id",
+				},
+				{
+					Name: "network_interface_id",
+				},
+				{
+					Name: "transit_gateway_id",
+				},
+			},
+		})
+		if diags.HasErrors() {
+			return diags
+		}
+
+		var nullAttributes int
+		for _, attribute := range body.Attributes {
+			isNull, err := runner.IsNullExpr(attribute.Expr)
+			if err != nil {
+				return err
+			}
+
+			if isNull {
+				nullAttributes = nullAttributes + 1
+			}
+		}
+
+		if len(body.Attributes)-nullAttributes > 1 {
+			runner.EmitIssue(
+				r,
+				"More than one routing target specified. It must be one.",
+				resource.DeclRange,
+			)
+		}
+
+		return nil
+	})
+}

--- a/rules/aws_route_specified_multiple_targets_test.go
+++ b/rules/aws_route_specified_multiple_targets_test.go
@@ -1,0 +1,68 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsRouteSpecifiedMultipleTargets(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "multiple route targets are specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+    egress_only_gateway_id = "eigw-1234abcd"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsRouteSpecifiedMultipleTargetsRule(),
+					Message: "More than one routing target specified. It must be one.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "single a route target is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "multiple targes found, but the second one is null",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+    egress_only_gateway_id = null
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsRouteSpecifiedMultipleTargetsRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -18,6 +18,8 @@ var Rules = append([]tflint.Rule{
 	NewAwsMqBrokerInvalidEngineTypeRule(),
 	NewAwsMqConfigurationInvalidEngineTypeRule(),
 	NewAwsResourceMissingTagsRule(),
+	NewAwsRouteNotSpecifiedTargetRule(),
+	NewAwsRouteSpecifiedMultipleTargetsRule(),
 	NewAwsS3BucketInvalidACLRule(),
 	NewAwsS3BucketInvalidRegionRule(),
 	NewAwsS3BucketNameRule(),


### PR DESCRIPTION
Migrate `aws_route_not_specified_target` and `aws_route_specified_multiple_targets` rules to this plugin.
This is the last rules migration. This means that it is ready to cut AWS rules from the TFLint core 🎉 