### PR TITLE
rule: Allow other fields of rule configs

### DIFF
--- a/rules/aws_s3_bucket_name.go
+++ b/rules/aws_s3_bucket_name.go
@@ -19,6 +19,8 @@ type AwsS3BucketNameRule struct {
 type awsS3BucketNameConfig struct {
 	Regex  string `hcl:"regex,optional"`
 	Prefix string `hcl:"prefix,optional"`
+
+	Remain hcl.Body `hcl:",remain"`
 }
 
 // NewAwsS3BucketNameRule returns a new rule with default attributes


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/41

Originally, `DecodeRuleConfig` parses only remains (except `enabled`) of a rule config. However, it contains the `enabled` attribute in the plugin system.