### PR TITLE
docs: Fix regex in aws_s3_bucket_name

### DIFF
--- a/docs/rules/aws_s3_bucket_name.md
+++ b/docs/rules/aws_s3_bucket_name.md
@@ -7,7 +7,7 @@ Ensures all S3 bucket names match the specified naming rules.
 ```hcl
 rule "aws_s3_bucket_name" {
   enabled = true
-  regex = "[a-z\-]+"
+  regex = "^[a-z\\-]+$"
   prefix = "my-org"
 }
 ```


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/41

Escapes are required when using backslashes in HCL language string literals.