### PR TITLE
Add rule generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,13 @@ You can easily install the built plugin with the following:
 ```
 $ make install
 ```
+
+## Add a new rule
+
+If you are interested in adding a new rule to this ruleset, you can use the generator. Run the following command:
+
+```
+$ go run ./rules/generator
+```
+
+Follow the instructions to edit the generated files and open a new pull request.

--- a/docs/rules/rule.md.tmpl
+++ b/docs/rules/rule.md.tmpl
@@ -1,0 +1,26 @@
+# {{ .RuleName }}
+
+// TODO: Write the rule's description here
+
+## Example
+
+```hcl
+resource "null_resource" "foo" {
+  // TODO: Write the example Terraform code which violates the rule
+}
+```
+
+```
+$ tflint
+
+// TODO: Write the output when inspects the above code
+
+```
+
+## Why
+
+// TODO: Write why you should follow the rule. This section is also a place to explain the value of the rule
+
+## How To Fix
+
+// TODO: Write how to fix it to avoid the problem

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.37.1
+	github.com/dave/dst v0.26.2
 	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.4
 	github.com/hashicorp/aws-sdk-go-base v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,12 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/dave/dst v0.26.2 h1:lnxLAKI3tx7MgLNVDirFCsDTlTG9nKTk7GcptKcWSwY=
+github.com/dave/dst v0.26.2/go.mod h1:UMDJuIRPfyUCC78eFuB+SV/WI8oDeyFDvM/JR6NI3IU=
+github.com/dave/gopackages v0.0.0-20170318123100-46e7023ec56e/go.mod h1:i00+b/gKdIDIxuLDFob7ustLAVqhsZRk2qVZrArELGQ=
+github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
+github.com/dave/kerr v0.0.0-20170318121727-bc25dd6abe8e/go.mod h1:qZqlPyPvfsDJt+3wHJ1EvSXDuVjFTK0j2p/ca+gtsb8=
+github.com/dave/rebecca v0.9.1/go.mod h1:N6XYdMD/OKw3lkF3ywh8Z6wPGuwNFDNtWYEMFWEmXBA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -156,6 +162,7 @@ github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPg
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0 h1:pMen7vLs8nvgEYhywH3KDWJIJTeEr2ULsVWHWYHQyBs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+github.com/google/pprof v0.0.0-20181127221834-b4f47329b966/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -362,6 +369,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+golang.org/x/arch v0.0.0-20180920145803-b19384d3c130/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -454,6 +462,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -534,6 +543,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -628,6 +638,8 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/src-d/go-billy.v4 v4.3.0 h1:KtlZ4c1OWbIs4jCv5ZXrTqG8EQocr0g/d4DjNg70aek=
+gopkg.in/src-d/go-billy.v4 v4.3.0/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=

--- a/rules/generator-utils/main.go
+++ b/rules/generator-utils/main.go
@@ -45,5 +45,5 @@ func GenerateFile(fileName string, tmplName string, meta interface{}) {
 // The difference from GenerateFile function is to output logs
 func GenerateFileWithLogs(fileName string, tmplName string, meta interface{}) {
 	GenerateFile(fileName, tmplName, meta)
-	fmt.Printf("Create: %s\n", fileName)
+	fmt.Printf("Created: %s\n", fileName)
 }

--- a/rules/generator/main.go
+++ b/rules/generator/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"go/format"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+	utils "github.com/terraform-linters/tflint-ruleset-aws/rules/generator-utils"
+)
+
+type metadata struct {
+	RuleName   string
+	RuleNameCC string
+}
+
+func main() {
+	buf := bufio.NewReader(os.Stdin)
+	fmt.Print("Rule name? (e.g. aws_instance_invalid_type): ")
+	ruleName, err := buf.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	ruleName = strings.Trim(ruleName, "\n")
+
+	meta := &metadata{RuleNameCC: utils.ToCamel(ruleName), RuleName: ruleName}
+
+	utils.GenerateFileWithLogs(fmt.Sprintf("rules/%s.go", ruleName), "rules/rule.go.tmpl", meta)
+	utils.GenerateFileWithLogs(fmt.Sprintf("rules/%s_test.go", ruleName), "rules/rule_test.go.tmpl", meta)
+	utils.GenerateFileWithLogs(fmt.Sprintf("docs/rules/%s.md", ruleName), "docs/rules/rule.md.tmpl", meta)
+
+	src, err := ioutil.ReadFile("rules/provider.go")
+	if err != nil {
+		panic(err)
+	}
+	dstf, err := decorator.Parse(src)
+	if err != nil {
+		panic(err)
+	}
+
+	dst.Inspect(dstf, func(n dst.Node) bool {
+		switch node := n.(type) {
+		case *dst.CompositeLit:
+			expr := &dst.CallExpr{
+				Fun: &dst.Ident{
+					Name: fmt.Sprintf("New%sRule", meta.RuleNameCC),
+				},
+			}
+			expr.Decs.Before = dst.NewLine
+			expr.Decs.After = dst.NewLine
+			node.Elts = append(node.Elts, expr)
+		}
+		return true
+	})
+
+	fset, astf, err := decorator.RestoreFile(dstf)
+	if err != nil {
+		panic(err)
+	}
+
+	fp, err := os.OpenFile("rules/provider.go", os.O_RDWR, 0755)
+	if err != nil {
+		panic(err)
+	}
+	if err := format.Node(fp, fset, astf); err != nil {
+		panic(err)
+	}
+	fmt.Println("Modified: rules/provider.go")
+
+	fmt.Println(`
+TODO:
+1. Remove all "TODO" comments from generated files.
+2. Write implementation of the rule.
+3. Add a link to the generated documentation into docs/rules/README.md`)
+}

--- a/rules/rule.go.tmpl
+++ b/rules/rule.go.tmpl
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// TODO: Write the rule's description here
+// {{ .RuleNameCC }}Rule checks ...
+type {{ .RuleNameCC }}Rule struct {
+	resourceType  string
+	attributeName string
+}
+
+// New{{ .RuleNameCC }}Rule returns new rule with default attributes
+func New{{ .RuleNameCC }}Rule() *{{ .RuleNameCC }}Rule {
+	return &{{ .RuleNameCC }}Rule{
+		// TODO: Write resource type and attribute name here
+		resourceType:  "...",
+		attributeName: "...",
+	}
+}
+
+// Name returns the rule name
+func (r *{{ .RuleNameCC }}Rule) Name() string {
+	return "{{ .RuleName }}"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *{{ .RuleNameCC }}Rule) Enabled() bool {
+	// TODO: Determine whether the rule is enabled by default
+	return true
+}
+
+// Severity returns the rule severity
+func (r *{{ .RuleNameCC }}Rule) Severity() string {
+	// TODO: Determine the rule's severiry
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *{{ .RuleNameCC }}Rule) Link() string {
+	// TODO: If the rule is so trivial that no documentation is needed, return "" instead.
+	return project.ReferenceLink(r.Name())
+}
+
+// TODO: Write the details of the inspection
+// Check checks ...
+func (r *{{ .RuleNameCC }}Rule) Check(runner tflint.Runner) error {
+	// TODO: Write the implementation here. See this documentation for what tflint.Runner can do.
+	//       https://pkg.go.dev/github.com/terraform-linters/tflint-plugin-sdk/tflint#Runner
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if val == "" {
+				runner.EmitIssueOnExpr(
+					r,
+					"TODO",
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/rule_test.go.tmpl
+++ b/rules/rule_test.go.tmpl
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_{{ .RuleNameCC }}(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "basic",
+			Content: `
+resource "null_resource" "null" {
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    New{{ .RuleNameCC }}Rule(),
+					Message: "TODO",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 0, Column: 0},
+						End:      hcl.Pos{Line: 0, Column: 0},
+					},
+				},
+			},
+		},
+	}
+
+	rule := New{{ .RuleNameCC }}Rule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}


### PR DESCRIPTION
Add a rule generator to help new contributors add rules. This is a modified version of the script that previously existed in the core repository. you can use a generator like the following:

```console
$ go run ./rules/generator
Rule name? (e.g. aws_instance_invalid_type): aws_instance_example_type
Created: rules/aws_instance_example_type.go
Created: rules/aws_instance_example_type_test.go
Created: docs/rules/aws_instance_example_type.md
Modified: rules/provider.go

TODO:
1. Remove all "TODO" comments from generated files.
2. Write implementation of the rule.
3. Add a link to the generated documentation into docs/rules/README.md
```