### PR TITLE
Update link to full list of rules

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -46,7 +46,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 
 #### SDK-based Validations
 
-700+ rules based on the aws-sdk validations are also available. See [full list](../../rules/awsrules/models/).
+700+ rules based on the aws-sdk validations are also available. See [full list](../../rules/models/).
 
 ### Best Practices
 


### PR DESCRIPTION
The old link 404'd - looks like the repo was reorganized at some point and this link needs to be updated to match.