### PR TITLE
Update aws_mq_broker_invalid_engine_type.go

### DIFF
--- a/rules/aws_mq_broker_invalid_engine_type.go
+++ b/rules/aws_mq_broker_invalid_engine_type.go
@@ -19,6 +19,7 @@ func NewAwsMqBrokerInvalidEngineTypeRule() *AwsMqBrokerInvalidEngineTypeRule {
 		attributeName: "engine_type",
 		enum: []string{
 			"ActiveMQ",
+			"RabbitMQ"
 		},
 	}
 }

--- a/rules/aws_mq_broker_invalid_engine_type.go
+++ b/rules/aws_mq_broker_invalid_engine_type.go
@@ -19,7 +19,7 @@ func NewAwsMqBrokerInvalidEngineTypeRule() *AwsMqBrokerInvalidEngineTypeRule {
 		attributeName: "engine_type",
 		enum: []string{
 			"ActiveMQ",
-			"RabbitMQ"
+			"RabbitMQ",
 		},
 	}
 }


### PR DESCRIPTION
Adding support for RabbitMQ Engine type in aws mq. 

RabbitMQ was recently added as a supported engine type in AWS. Tflint throws an error when the engine type is set as "RabbitMQ", which is now a valid engine type in the aws terraform provider. 

This change allows for the use of the "RabbitMQ" engine type. 