### PR TITLE
add TFLINT_PLUGIN_DIR option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This ruleset focus on possible errors and best practices about AWS resources. Ma
 
 ## Installation
 
-Download the plugin and place it in `~/.tflint.d/plugins/tflint-ruleset-aws` (or `./.tflint.d/plugins/tflint-ruleset-aws`). When using the plugin, configure as follows in `.tflint.hcl`:
+Download the plugin and place it in `~/.tflint.d/plugins/tflint-ruleset-aws` (or `./.tflint.d/plugins/tflint-ruleset-aws`). You can also set another plugin location with the `TFLINT_PLUGIN_DIR` environment variable. When using the plugin, configure as follows in `.tflint.hcl`:
 
 ```hcl
 plugin "aws" {


### PR DESCRIPTION
Hey, I was working with this tool and was confused by the documentation. Upon reading this README, I thought that the two options described here were the only two available. I happened to be working in an environment where the `TFLINT_PLUGIN_DIR` option was the only one that would work. 

I eventually found out about the option from [these docs](https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md). I think listing all three plugin directory methods would be clearer and might save someone time down the road.