### PR TITLE
rule: Add aws_api_gateway_model_invalid_name rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -10,6 +10,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 | --- | --- | --- | --- |
 |aws_alb_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_alb_invalid_subnet|Disallow using invalid subnets|✔|✔|
+|aws_api_gateway_model_invalid_name|Disallow using invalid name||✔|
 |aws_db_instance_invalid_db_subnet_group|Disallow using invalid subnet group name|✔|✔|
 |[aws_db_instance_invalid_engine](aws_db_instance_invalid_engine.md)|Disallow using invalid engine name||✔|
 |aws_db_instance_invalid_option_group|Disallow using invalid option group|✔|✔|

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -10,6 +10,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 | --- | --- | --- | --- |
 |aws_alb_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_alb_invalid_subnet|Disallow using invalid subnets|✔|✔|
+|aws_api_gateway_model_invalid_name|Disallow using invalid name||✔|
 |aws_db_instance_invalid_db_subnet_group|Disallow using invalid subnet group name|✔|✔|
 |[aws_db_instance_invalid_engine](aws_db_instance_invalid_engine.md)|Disallow using invalid engine name||✔|
 |aws_db_instance_invalid_option_group|Disallow using invalid option group|✔|✔|

--- a/rules/aws_api_gateway_model_invalid_name.go
+++ b/rules/aws_api_gateway_model_invalid_name.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsAPIGatewayModelInvalidNameRule checks the name is alphanumeric
+type AwsAPIGatewayModelInvalidNameRule struct {
+	resourceType  string
+	attributeName string
+	pattern       *regexp.Regexp
+}
+
+// NewAwsAPIGatewayModelInvalidNameRule returns new rule with default attributes
+func NewAwsAPIGatewayModelInvalidNameRule() *AwsAPIGatewayModelInvalidNameRule {
+	return &AwsAPIGatewayModelInvalidNameRule{
+		resourceType:  "aws_api_gateway_model",
+		attributeName: "name",
+		pattern:       regexp.MustCompile("^[a-zA-Z0-9]+$"),
+	}
+}
+
+// Name returns the rule name
+func (r *AwsAPIGatewayModelInvalidNameRule) Name() string {
+	return "aws_api_gateway_model_invalid_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsAPIGatewayModelInvalidNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsAPIGatewayModelInvalidNameRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsAPIGatewayModelInvalidNameRule) Link() string {
+	return ""
+}
+
+// Check checks the name attributes is matched with ^[a-zA-Z0-9]+$ regexp
+func (r *AwsAPIGatewayModelInvalidNameRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.pattern.MatchString(val) {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`%s does not match valid pattern %s`, val, `^[a-zA-Z0-9]+$`),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_api_gateway_model_invalid_name_test.go
+++ b/rules/aws_api_gateway_model_invalid_name_test.go
@@ -1,0 +1,57 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsAPIGatewayModelInvalidName(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "underscore",
+			Content: `
+resource "aws_api_gateway_model" "demo" {
+  name = "demo_model"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsAPIGatewayModelInvalidNameRule(),
+					Message: `demo_model does not match valid pattern ^[a-zA-Z0-9]+$`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 22},
+					},
+				},
+			},
+		},
+		{
+			Name: "alphanumeric",
+			Content: `
+resource "aws_api_gateway_model" "demo" {
+  name = "user"
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsAPIGatewayModelInvalidNameRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -28,4 +28,5 @@ var Rules = append([]tflint.Rule{
 	NewAwsS3BucketInvalidRegionRule(),
 	NewAwsS3BucketNameRule(),
 	NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
+	NewAwsAPIGatewayModelInvalidNameRule(),
 }, models.Rules...)


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/98

Only alphanumeric characters are allowed in the name of `aws_api_gateway_model`. This rule checks the name is matched with `^[a-zA-Z0-9]+$` regexp pattern.