### PR TITLE
rule: Pass wantType explicitly instead of map[string]string

### DIFF
--- a/rules/aws_resource_missing_tags.go
+++ b/rules/aws_resource_missing_tags.go
@@ -94,7 +94,8 @@ func (r *AwsResourceMissingTagsRule) Check(runner tflint.Runner) error {
 			if attribute, ok := body.Attributes[tagsAttributeName]; ok {
 				log.Printf("[DEBUG] Walk `%s` attribute", resource.Type+"."+resource.Name+"."+tagsAttributeName)
 				resourceTags := make(map[string]string)
-				err := runner.EvaluateExpr(attribute.Expr, &resourceTags, nil)
+				wantType := cty.Map(cty.String)
+				err := runner.EvaluateExpr(attribute.Expr, &resourceTags, &wantType)
 				err = runner.EnsureNoError(err, func() error {
 					r.emitIssueOnExpr(runner, resourceTags, config, attribute.Expr)
 					return nil


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/issues/1102

If no type is passed, EvaluateExpr sends the resulting value to the host server for type inference:
https://github.com/terraform-linters/tflint-plugin-sdk/blob/v0.8.2/tflint/client/client.go#L239-L252
In this issue, `map[string]string` is sent, which causes an encoding error.

Avoid this error by explicitly passing the type to prevent `map[string]string` from being sent.