### PR TITLE
Update GoReleaser config to build arm64 for M1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Go
       uses: actions/setup-go@v2.1.3
       with:
@@ -29,7 +31,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run GoReleaser
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        VERSION: v0.143.0
-      run: curl -sL https://git.io/goreleaser | bash
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: v0.143.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,5 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         version: v0.143.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
       - 386
       - amd64
       - arm
+      - arm64
 archives:
   - id: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
This should solve https://github.com/terraform-linters/tflint-ruleset-aws/issues/124

While I'm in here, I also updated the actions config to use [the published GoReleaser action](https://github.com/goreleaser/goreleaser-action) instead of a custom script.