### PR TITLE
aws_elasticache_replication_group

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -52,6 +52,7 @@ These rules enforce best practices and naming conventions:
 |[aws_db_instance_default_parameter_group](aws_db_instance_default_parameter_group.md)|Disallow using default DB parameter group|✔|
 |[aws_elasticache_cluster_previous_type](aws_elasticache_cluster_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_cluster_default_parameter_group](aws_elasticache_cluster_default_parameter_group.md)|Disallow using default parameter group|✔|
+|[aws_elasticache_replication_group_previous_type](aws_elasticache_replication_group_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_replication_group_default_parameter_group](aws_elasticache_replication_group_default_parameter_group.md)|Disallow using default parameter group|✔|
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -51,6 +51,7 @@ These rules enforce best practices and naming conventions:
 |[aws_db_instance_default_parameter_group](aws_db_instance_default_parameter_group.md)|Disallow using default DB parameter group|✔|
 |[aws_elasticache_cluster_previous_type](aws_elasticache_cluster_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_cluster_default_parameter_group](aws_elasticache_cluster_default_parameter_group.md)|Disallow using default parameter group|✔|
+|[aws_elasticache_replication_group_default_parameter_group](aws_elasticache_replication_group_default_parameter_group.md)|Disallow using default parameter group|✔|
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -21,6 +21,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_elasticache_cluster_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elasticache_cluster_invalid_subnet_group|Disallow using invalid subnet group|✔|✔|
 |aws_elasticache_cluster_invalid_type|Disallow using invalid node type||✔|
+|[aws_elasticache_replication_group_invalid_type](aws_elasticache_replication_group_invalid_type)|Disallow using invalid node type||✔|
 |aws_elb_invalid_instance|Disallow using invalid instances|✔|✔|
 |aws_elb_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elb_invalid_subnet|Disallow using invalid subnets|✔|✔|

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -20,7 +20,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_elasticache_cluster_invalid_parameter_group|Disallow using invalid parameter group|✔|✔|
 |aws_elasticache_cluster_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elasticache_cluster_invalid_subnet_group|Disallow using invalid subnet group|✔|✔|
-|aws_elasticache_cluster_invalid_type|Disallow using invalid node type||✔|
+|[aws_elasticache_cluster_invalid_type](aws_elasticache_cluster_invalid_type)|Disallow using invalid node type||✔|
 |[aws_elasticache_replication_group_invalid_type](aws_elasticache_replication_group_invalid_type)|Disallow using invalid node type||✔|
 |aws_elb_invalid_instance|Disallow using invalid instances|✔|✔|
 |aws_elb_invalid_security_group|Disallow using invalid security groups|✔|✔|

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -52,6 +52,7 @@ These rules enforce best practices and naming conventions:
 |[aws_db_instance_default_parameter_group](aws_db_instance_default_parameter_group.md)|Disallow using default DB parameter group|✔|
 |[aws_elasticache_cluster_previous_type](aws_elasticache_cluster_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_cluster_default_parameter_group](aws_elasticache_cluster_default_parameter_group.md)|Disallow using default parameter group|✔|
+|[aws_elasticache_replication_group_previous_type](aws_elasticache_replication_group_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_replication_group_default_parameter_group](aws_elasticache_replication_group_default_parameter_group.md)|Disallow using default parameter group|✔|
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -51,6 +51,7 @@ These rules enforce best practices and naming conventions:
 |[aws_db_instance_default_parameter_group](aws_db_instance_default_parameter_group.md)|Disallow using default DB parameter group|✔|
 |[aws_elasticache_cluster_previous_type](aws_elasticache_cluster_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_cluster_default_parameter_group](aws_elasticache_cluster_default_parameter_group.md)|Disallow using default parameter group|✔|
+|[aws_elasticache_replication_group_default_parameter_group](aws_elasticache_replication_group_default_parameter_group.md)|Disallow using default parameter group|✔|
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -21,6 +21,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_elasticache_cluster_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elasticache_cluster_invalid_subnet_group|Disallow using invalid subnet group|✔|✔|
 |aws_elasticache_cluster_invalid_type|Disallow using invalid node type||✔|
+|[aws_elasticache_replication_group_invalid_type](aws_elasticache_replication_group_invalid_type)|Disallow using invalid node type||✔|
 |aws_elb_invalid_instance|Disallow using invalid instances|✔|✔|
 |aws_elb_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elb_invalid_subnet|Disallow using invalid subnets|✔|✔|

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -20,7 +20,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_elasticache_cluster_invalid_parameter_group|Disallow using invalid parameter group|✔|✔|
 |aws_elasticache_cluster_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elasticache_cluster_invalid_subnet_group|Disallow using invalid subnet group|✔|✔|
-|aws_elasticache_cluster_invalid_type|Disallow using invalid node type||✔|
+|[aws_elasticache_cluster_invalid_type](aws_elasticache_cluster_invalid_type)|Disallow using invalid node type||✔|
 |[aws_elasticache_replication_group_invalid_type](aws_elasticache_replication_group_invalid_type)|Disallow using invalid node type||✔|
 |aws_elb_invalid_instance|Disallow using invalid instances|✔|✔|
 |aws_elb_invalid_security_group|Disallow using invalid security groups|✔|✔|

--- a/docs/rules/aws_elasticache_cluster_invalid_type.md
+++ b/docs/rules/aws_elasticache_cluster_invalid_type.md
@@ -1,0 +1,40 @@
+# aws_elasticache_cluster_invalid_type
+
+Disallow using invalid type.
+
+## Example
+
+```hcl
+resource "aws_elasticache_cluster" "default" {
+  node_type                     = "cache.t3.mini" // invalid type!
+  engine_version                = "6.x"
+  maintenance_window            = "thu:02:30-thu:03:30"
+  num_cache_nodes               = 1
+  apply_immediately             = false
+  parameter_group_name          = "custom.redis6.x.cluster.on"
+  port                          = 6379
+  cluster_id                    = "cluster_id"
+  snapshot_retention_limit      = 1
+  subnet_group_name             = aws_elasticache_subnet_group.private.name
+  security_group_ids            = [aws_security_group.redis_service.id]
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: "cache.t3.mini" is an invalid node type. (aws_elasticache_cluster_invalid_type)
+
+  on template.tf line 5:
+   2:   node_type       = "cache.t3.mini" // invalid type!
+
+```
+
+## Why
+
+Apply will fail. (Plan will succeed with the invalid value though)
+
+## How To Fix
+
+Select valid type according to the [document](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)

--- a/docs/rules/aws_elasticache_replication_group_default_parameter_group.md
+++ b/docs/rules/aws_elasticache_replication_group_default_parameter_group.md
@@ -22,12 +22,9 @@ resource "aws_elasticache_replication_group" "redis" {
 ```
 $ tflint
 1 issue(s) found:
-
 Notice: "default.redis3.2" is default parameter group. You cannot edit it. (aws_elasticache_replication_group_default_parameter_group)
-
   on template.tf line 9:
    9:   parameter_group_name = "default.redis3.2" // default parameter group!
-
 ```
 
 ## Why

--- a/docs/rules/aws_elasticache_replication_group_default_parameter_group.md
+++ b/docs/rules/aws_elasticache_replication_group_default_parameter_group.md
@@ -1,11 +1,11 @@
-# aws_elasticache_cluster_default_parameter_group
+# aws_elasticache_replication_group_default_parameter_group
 
 Disallow using default parameter group.
 
 ## Example
 
 ```hcl
-resource "aws_elasticache_cluster" "redis" {
+resource "aws_elasticache_replication_group" "redis" {
   cluster_id           = "app"
   engine               = "redis"
   engine_version       = "3.2.4"
@@ -23,7 +23,7 @@ resource "aws_elasticache_cluster" "redis" {
 $ tflint
 1 issue(s) found:
 
-Notice: "default.redis3.2" is default parameter group. You cannot edit it. (aws_elasticache_cluster_default_parameter_group)
+Notice: "default.redis3.2" is default parameter group. You cannot edit it. (aws_elasticache_replication_group_default_parameter_group)
 
   on template.tf line 9:
    9:   parameter_group_name = "default.redis3.2" // default parameter group!

--- a/docs/rules/aws_elasticache_replication_group_invalid_type.md
+++ b/docs/rules/aws_elasticache_replication_group_invalid_type.md
@@ -1,0 +1,47 @@
+# aws_elasticache_replication_group_invalid_type
+
+Disallow using invalid type.
+
+## Example
+
+```hcl
+resource "aws_elasticache_replication_group" "default" {
+  node_type                     = "cache.t3.mini" // invalid type!
+  at_rest_encryption_enabled    = true
+  automatic_failover_enabled    = true
+  engine_version                = "6.x"
+  maintenance_window            = "thu:02:30-thu:03:30"
+  apply_immediately             = false
+  parameter_group_name          = "custom.redis6.x.cluster.on"
+  port                          = 6379
+  replication_group_description = " "
+  replication_group_id          = "replication_group_id"
+  snapshot_retention_limit      = 1
+  subnet_group_name             = aws_elasticache_subnet_group.private.name
+  security_group_ids            = [aws_security_group.redis_service.id]
+
+  cluster_mode {
+    replicas_per_node_group = 1
+    num_node_groups         = 2
+  }
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: "cache.t3.mini" is an invalid node type. (aws_elasticache_replication_group_invalid_type)
+
+  on template.tf line 5:
+   2:   node_type       = "cache.t3.mini" // invalid type!
+
+```
+
+## Why
+
+Apply will fail. (Plan will succeed with the invalid value though)
+
+## How To Fix
+
+Select valid type according to the [document](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)

--- a/docs/rules/aws_elasticache_replication_group_previous_type.md
+++ b/docs/rules/aws_elasticache_replication_group_previous_type.md
@@ -1,0 +1,47 @@
+# aws_elasticache_replication_group_previous_type
+
+Disallow using previous node types.
+
+## Example
+
+```hcl
+resource "aws_elasticache_replication_group" "default" {
+  node_type                     = "cache.t1.micro" // previous node type!
+  at_rest_encryption_enabled    = true
+  automatic_failover_enabled    = true
+  engine_version                = "6.x"
+  maintenance_window            = "thu:02:30-thu:03:30"
+  apply_immediately             = false
+  parameter_group_name          = "custom.redis6.x.cluster.on"
+  port                          = 6379
+  replication_group_description = " "
+  replication_group_id          = "replication_group_id"
+  snapshot_retention_limit      = 1
+  subnet_group_name             = aws_elasticache_subnet_group.private.name
+  security_group_ids            = [aws_security_group.redis_service.id]
+
+  cluster_mode {
+    replicas_per_node_group = 1
+    num_node_groups         = 2
+  }
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: "cache.t1.micro" is previous generation node type. (aws_elasticache_replication_group_previous_type)
+
+  on template.tf line 6:
+   2:   node_type            = "cache.t1.micro" // previous node type!
+
+```
+
+## Why
+
+Previous node types are inferior to current generation in terms of performance and fee. Unless there is a special reason, you should avoid to use these ones.
+
+## How To Fix
+
+Select a current generation node type according to the [upgrade paths](https://aws.amazon.com/elasticache/previous-generation/).

--- a/rules/aws_elasticache_replication_group_default_parameter_group.go
+++ b/rules/aws_elasticache_replication_group_default_parameter_group.go
@@ -43,7 +43,7 @@ func (r *AwsElastiCacheReplicationGroupDefaultParameterGroupRule) Link() string 
 	return project.ReferenceLink(r.Name())
 }
 
-var defaultElastiCacheParameterGroupRegexp = regexp.MustCompile("^default")
+var defaultElastiCacheReplicationParameterGroupRegexp = regexp.MustCompile("^default")
 
 // Check checks the parameter group name starts with `default`
 func (r *AwsElastiCacheReplicationGroupDefaultParameterGroupRule) Check(runner tflint.Runner) error {

--- a/rules/aws_elasticache_replication_group_default_parameter_group.go
+++ b/rules/aws_elasticache_replication_group_default_parameter_group.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsElastiCacheReplicationGroupDefaultParameterGroupRule checks whether the cluster use default parameter group
+type AwsElastiCacheReplicationGroupDefaultParameterGroupRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule returns new rule with default attributes
+func NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule() *AwsElastiCacheReplicationGroupDefaultParameterGroupRule {
+	return &AwsElastiCacheReplicationGroupDefaultParameterGroupRule{
+		resourceType:  "aws_elasticache_replication_group",
+		attributeName: "parameter_group_name",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheReplicationGroupDefaultParameterGroupRule) Name() string {
+	return "aws_elasticache_replication_group_default_parameter_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheReplicationGroupDefaultParameterGroupRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsElastiCacheReplicationGroupDefaultParameterGroupRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *AwsElastiCacheReplicationGroupDefaultParameterGroupRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+var defaultElastiCacheParameterGroupRegexp = regexp.MustCompile("^default")
+
+// Check checks the parameter group name starts with `default`
+func (r *AwsElastiCacheReplicationGroupDefaultParameterGroupRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var parameterGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &parameterGroup, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if defaultElastiCacheParameterGroupRegexp.Match([]byte(parameterGroup)) {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_elasticache_replication_group_default_parameter_group_test.go
+++ b/rules/aws_elasticache_replication_group_default_parameter_group_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsElastiCacheReplicationGroupDefaultParameterGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "default.redis3.2 is default parameter group",
+			Content: `
+resource "aws_elasticache_replication_group" "cache" {
+    parameter_group_name = "default.redis3.2"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
+					Message: "\"default.redis3.2\" is default parameter group. You cannot edit it.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 28},
+						End:      hcl.Pos{Line: 3, Column: 46},
+					},
+				},
+			},
+		},
+		{
+			Name: "application3.2 is not default parameter group",
+			Content: `
+resource "aws_elasticache_replication_group" "cache" {
+    parameter_group_name = "application3.2"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_elasticache_replication_group_invalid_type.go
+++ b/rules/aws_elasticache_replication_group_invalid_type.go
@@ -1,0 +1,126 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsElastiCacheReplicationGroupInvalidTypeRule checks whether "aws_elasticache_replication_group" has invalid node type.
+type AwsElastiCacheReplicationGroupInvalidTypeRule struct {
+	resourceType  string
+	attributeName string
+	nodeTypes     map[string]bool
+}
+
+// NewAwsElastiCacheReplicationGroupInvalidTypeRule returns new rule with default attributes
+func NewAwsElastiCacheReplicationGroupInvalidTypeRule() *AwsElastiCacheReplicationGroupInvalidTypeRule {
+	return &AwsElastiCacheReplicationGroupInvalidTypeRule{
+		resourceType:  "aws_elasticache_replication_group",
+		attributeName: "node_type",
+		nodeTypes: map[string]bool{
+			"cache.t2.micro":     true,
+			"cache.t2.small":     true,
+			"cache.t2.medium":    true,
+			"cache.t3.micro":     true,
+			"cache.t3.small":     true,
+			"cache.t3.medium":    true,
+			"cache.m3.medium":    true,
+			"cache.m3.large":     true,
+			"cache.m3.xlarge":    true,
+			"cache.m3.2xlarge":   true,
+			"cache.m4.large":     true,
+			"cache.m4.xlarge":    true,
+			"cache.m4.2xlarge":   true,
+			"cache.m4.4xlarge":   true,
+			"cache.m4.10xlarge":  true,
+			"cache.m5.large":     true,
+			"cache.m5.xlarge":    true,
+			"cache.m5.2xlarge":   true,
+			"cache.m5.4xlarge":   true,
+			"cache.m5.12xlarge":  true,
+			"cache.m5.24xlarge":  true,
+			"cache.m6g.large":    true,
+			"cache.m6g.xlarge":   true,
+			"cache.m6g.2xlarge":  true,
+			"cache.m6g.4xlarge":  true,
+			"cache.m6g.8xlarge":  true,
+			"cache.m6g.12xlarge": true,
+			"cache.m6g.16xlarge": true,
+			"cache.r3.large":     true,
+			"cache.r3.xlarge":    true,
+			"cache.r3.2xlarge":   true,
+			"cache.r3.4xlarge":   true,
+			"cache.r3.8xlarge":   true,
+			"cache.r4.large":     true,
+			"cache.r4.xlarge":    true,
+			"cache.r4.2xlarge":   true,
+			"cache.r4.4xlarge":   true,
+			"cache.r4.8xlarge":   true,
+			"cache.r4.16xlarge":  true,
+			"cache.r5.large":     true,
+			"cache.r5.xlarge":    true,
+			"cache.r5.2xlarge":   true,
+			"cache.r5.4xlarge":   true,
+			"cache.r5.12xlarge":  true,
+			"cache.r5.24xlarge":  true,
+			"cache.r6g.large":    true,
+			"cache.r6g.xlarge":   true,
+			"cache.r6g.2xlarge":  true,
+			"cache.r6g.4xlarge":  true,
+			"cache.r6g.8xlarge":  true,
+			"cache.r6g.12xlarge": true,
+			"cache.r6g.16xlarge": true,
+			"cache.m1.small":     true,
+			"cache.m1.medium":    true,
+			"cache.m1.large":     true,
+			"cache.m1.xlarge":    true,
+			"cache.m2.xlarge":    true,
+			"cache.m2.2xlarge":   true,
+			"cache.m2.4xlarge":   true,
+			"cache.c1.xlarge":    true,
+			"cache.t1.micro":     true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheReplicationGroupInvalidTypeRule) Name() string {
+	return "aws_elasticache_replication_group_invalid_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheReplicationGroupInvalidTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsElastiCacheReplicationGroupInvalidTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsElastiCacheReplicationGroupInvalidTypeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether "aws_elasticache_replication_group" has invalid node type.
+func (r *AwsElastiCacheReplicationGroupInvalidTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var nodeType string
+		err := runner.EvaluateExpr(attribute.Expr, &nodeType, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.nodeTypes[nodeType] {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf("\"%s\" is invalid node type.", nodeType),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_elasticache_replication_group_invalid_type_test.go
+++ b/rules/aws_elasticache_replication_group_invalid_type_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsElastiCacheReplicationGroupInvalidType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "t2.micro is invalid",
+			Content: `
+resource "aws_elasticache_replication_group" "redis" {
+    node_type = "t2.micro"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsElastiCacheReplicationGroupInvalidTypeRule(),
+					Message: "\"t2.micro\" is invalid node type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 17},
+						End:      hcl.Pos{Line: 3, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "cache.t2.micro is valid",
+			Content: `
+resource "aws_elasticache_replication_group" "redis" {
+    node_type = "cache.t2.micro"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsElastiCacheReplicationGroupInvalidTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_elasticache_replication_group_previous_type.go
+++ b/rules/aws_elasticache_replication_group_previous_type.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsElastiCacheReplicationGroupPreviousTypeRule checks whether the resource uses previous generation node type
+type AwsElastiCacheReplicationGroupPreviousTypeRule struct {
+	resourceType      string
+	attributeName     string
+	previousNodeTypes map[string]bool
+}
+
+// NewAwsElastiCacheReplicationGroupPreviousTypeRule returns new rule with default attributes
+func NewAwsElastiCacheReplicationGroupPreviousTypeRule() *AwsElastiCacheReplicationGroupPreviousTypeRule {
+	return &AwsElastiCacheReplicationGroupPreviousTypeRule{
+		resourceType:  "aws_elasticache_replication_group",
+		attributeName: "node_type",
+		previousNodeTypes: map[string]bool{
+			"cache.m1.small":   true,
+			"cache.m1.medium":  true,
+			"cache.m1.large":   true,
+			"cache.m1.xlarge":  true,
+			"cache.m2.xlarge":  true,
+			"cache.m2.2xlarge": true,
+			"cache.m2.4xlarge": true,
+			"cache.m3.medium":  true,
+			"cache.m3.large":   true,
+			"cache.m3.xlarge":  true,
+			"cache.m3.2xlarge": true,
+			"cache.r3.large":   true,
+			"cache.r3.xlarge":  true,
+			"cache.r3.2xlarge": true,
+			"cache.r3.4xlarge": true,
+			"cache.r3.8xlarge": true,
+			"cache.c1.xlarge":  true,
+			"cache.t1.micro":   true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Name() string {
+	return "aws_elasticache_replication_group_previous_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether the resource's `node_type` is included in the list of previous generation node type
+func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var nodeType string
+		err := runner.EvaluateExpr(attribute.Expr, &nodeType, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if r.previousNodeTypes[nodeType] {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),
+					attribute.Expr.Range(),
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_elasticache_replication_group_previous_type_test.go
+++ b/rules/aws_elasticache_replication_group_previous_type_test.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsElastiCacheReplicationGroupPreviousType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "cache.t1.micro is previous type",
+			Content: `
+resource "aws_elasticache_replication_group" "redis" {
+    node_type = "cache.t1.micro"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsElastiCacheReplicationGroupPreviousTypeRule(),
+					Message: "\"cache.t1.micro\" is previous generation node type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 17},
+						End:      hcl.Pos{Line: 3, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			Name: "cache.t2.micro is not previous type",
+			Content: `
+resource "aws_elasticache_replication_group" "redis" {
+    node_type = "cache.t2.micro"
+}`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsElastiCacheReplicationGroupPreviousTypeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -30,4 +30,5 @@ var Rules = append([]tflint.Rule{
 	NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
 	NewAwsAPIGatewayModelInvalidNameRule(),
 	NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
+	NewAwsElastiCacheReplicationGroupInvalidTypeRule(),
 }, models.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -29,4 +29,5 @@ var Rules = append([]tflint.Rule{
 	NewAwsS3BucketNameRule(),
 	NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
 	NewAwsAPIGatewayModelInvalidNameRule(),
+	NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
 }, models.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -31,4 +31,5 @@ var Rules = append([]tflint.Rule{
 	NewAwsAPIGatewayModelInvalidNameRule(),
 	NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
 	NewAwsElastiCacheReplicationGroupInvalidTypeRule(),
+	NewAwsElastiCacheReplicationGroupPreviousTypeRule(),
 }, models.Rules...)


### PR DESCRIPTION
fixes terraform-linters/tflint-ruleset-aws#140

Adds rules for aws_elasticcache_replication_group resource