### PR TITLE
aws_iam_policy_sid

### DIFF
--- a/docs/rules/aws_iam_policy_sid_invalid_characters.md
+++ b/docs/rules/aws_iam_policy_sid_invalid_characters.md
@@ -1,0 +1,60 @@
+# aws_iam_policy_sid_invalid_characters
+
+AWS IAM policies have statement ids within each statement that must fit the regexp `^[a-zA-Z0-9]+$` otherwise the policy will fail.
+
+## Example
+
+```hcl
+resource "aws_iam_policy" "policy" {
+	name = "test_policy"
+	role = "test_role"
+	policy = <<-EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+			"Sid": "This contains invalid-characters.", //invalid Sid
+	    "Action": [
+	      "ec2:Describe*"
+			],
+			"Effect": "Allow",
+			"Resource": "arn:aws:s3:::<bucketname>/*"
+	  }
+	]
+}
+EOF
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: The policy's sid contains invalid characters. (aws_iam_policy_sid_invalid_characters)
+
+  on template.tf line 3:
+   3:   policy = <<-EOF
+ {
+ 	"Version": "2012-10-17",
+ 	"Statement": [
+ 	  {
+ 			"Sid": "This contains invalid-characters.", //invalid Sid
+ 	    "Action": [
+ 	      "ec2:Describe*"
+ 			],
+ 			"Effect": "Allow",
+ 			"Resource": "arn:aws:s3:::<bucketname>/*"
+ 	  }
+ 	]
+ }
+ EOF
+
+```
+
+## Why
+
+AWS will fail to create or update the policy if the Sid is not valid
+
+## How To Fix
+
+Make sure you Sid's fit the regexp `^[a-zA-Z0-9]+$`

--- a/docs/rules/aws_iam_policy_sid_invalid_characters.md
+++ b/docs/rules/aws_iam_policy_sid_invalid_characters.md
@@ -30,7 +30,7 @@ EOF
 $ tflint
 1 issue(s) found:
 
-Error: The policy's sid contains invalid characters. (aws_iam_policy_sid_invalid_characters)
+Error: The policy's sid ("This contains invalid-characters.") does not match "^[a-zA-Z0-9]+$". (aws_iam_policy_sid_invalid_characters)
 
   on template.tf line 3:
    3:   policy = <<-EOF

--- a/rules/aws_iam_policy_sid_invalid_characters.go
+++ b/rules/aws_iam_policy_sid_invalid_characters.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"encoding/json"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+	"regexp"
+)
+
+// AwsIAMPolicySidInvalidCharactersRule checks for invalid characters in SID
+type AwsIAMPolicySidInvalidCharactersRule struct {
+	resourceType    string
+	attributeName   string
+	validCharacters *regexp.Regexp
+}
+
+// NewAwsIAMPolicySidInvalidCharactersRule returns new rule with default attributes
+func NewAwsIAMPolicySidInvalidCharactersRule() *AwsIAMPolicySidInvalidCharactersRule {
+	return &AwsIAMPolicySidInvalidCharactersRule{
+		resourceType:    "aws_iam_policy",
+		attributeName:   "policy",
+		validCharacters: regexp.MustCompile(`^[a-zA-Z0-9]+$`),
+	}
+}
+
+// Name returns the rule name
+func (r *AwsIAMPolicySidInvalidCharactersRule) Name() string {
+	return "aws_iam_policy_sid_invalid_characters"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsIAMPolicySidInvalidCharactersRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsIAMPolicySidInvalidCharactersRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsIAMPolicySidInvalidCharactersRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks the unmarshaled policy and loops through statements checking for invalid statement ids
+func (r *AwsIAMPolicySidInvalidCharactersRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+		var unMarshaledPolicy interface{}
+		err = json.Unmarshal([]byte(val), &unMarshaledPolicy)
+		if err != nil {
+			return err
+		}
+		policy := unMarshaledPolicy.(map[string]interface{})
+		statements := policy["Statement"].([]interface{})
+
+		return runner.EnsureNoError(err, func() error {
+			for _, e := range statements {
+				statement := e.(map[string]interface{})
+				if r.validCharacters.MatchString(statement["Sid"].(string)) == false {
+					runner.EmitIssueOnExpr(
+						r,
+						"The policy's sid contains invalid characters.",
+						attribute.Expr,
+					)
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/aws_iam_policy_sid_invalid_characters_test.go
+++ b/rules/aws_iam_policy_sid_invalid_characters_test.go
@@ -1,0 +1,107 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsIAMPolicySidInvalidCharacters(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "single statement with invalid",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name = "test_policy"
+	role = "test_role"
+	policy = <<-EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+			"Sid": "This contains invalid-characters.",
+	    "Action": [
+	      "ec2:Describe*"
+			],
+			"Effect": "Allow",
+			"Resource": "arn:aws:s3:::<bucketname>/*"
+	  }
+	]
+}
+EOF
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsIAMPolicySidInvalidCharactersRule(),
+					Message: "The policy's sid contains invalid characters.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 5, Column: 11},
+						End:      hcl.Pos{Line: 19, Column: 4},
+					},
+				},
+			},
+		},
+		{
+			Name: "two statements second invalid",
+			Content: `
+resource "aws_iam_policy" "policy2" {
+	name = "test_policy"
+	role = "test_role"
+	policy = <<-EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+			"Sid": "ThisIsAValidSid",
+	    "Action": [
+	      "ec2:Describe*"
+			],
+			"Effect": "Allow",
+			"Resource": "arn:aws:s3:::<bucketname>/*"
+	  },
+	  {
+			"Sid": "This contains invalid-characters.",
+	    "Action": [
+	      "ec2:Describe*"
+			],
+			"Effect": "Allow",
+			"Resource": "arn:aws:s3:::<bucketname>/*"
+	  }
+	]
+}
+EOF
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsIAMPolicySidInvalidCharactersRule(),
+					Message: "The policy's sid contains invalid characters.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 5, Column: 11},
+						End:      hcl.Pos{Line: 27, Column: 4},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsIAMPolicySidInvalidCharactersRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_iam_policy_sid_invalid_characters_test.go
+++ b/rules/aws_iam_policy_sid_invalid_characters_test.go
@@ -39,7 +39,7 @@ EOF
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsIAMPolicySidInvalidCharactersRule(),
-					Message: "The policy's sid contains invalid characters.",
+					Message: `The policy's sid ("This contains invalid-characters.") does not match "^[a-zA-Z0-9]+$".`,
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 5, Column: 11},
@@ -82,7 +82,7 @@ EOF
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsIAMPolicySidInvalidCharactersRule(),
-					Message: "The policy's sid contains invalid characters.",
+					Message: `The policy's sid ("This contains invalid-characters.") does not match "^[a-zA-Z0-9]+$".`,
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 5, Column: 11},

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -32,4 +32,5 @@ var Rules = append([]tflint.Rule{
 	NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
 	NewAwsElastiCacheReplicationGroupInvalidTypeRule(),
 	NewAwsElastiCacheReplicationGroupPreviousTypeRule(),
+	NewAwsIAMPolicySidInvalidCharactersRule(),
 }, models.Rules...)


### PR DESCRIPTION
add invalid sid rules fixes terraform-linters/tflint-ruleset-aws#149

This should loop through all SIDs in a policy and make sure all of them fit the pattern.