### PR TITLE
Fix typo in aws_elasticache_cluster_default_parameter_group.md

### DIFF
--- a/docs/rules/aws_elasticache_cluster_default_parameter_group.md
+++ b/docs/rules/aws_elasticache_cluster_default_parameter_group.md
@@ -13,7 +13,7 @@ resource "aws_elasticache_cluster" "redis" {
   node_type            = "cache.m4.large"
   num_cache_nodes      = 1
   port                 = 6379
-  parameter_group_name = "default.redis3.2" // default paramete group!
+  parameter_group_name = "default.redis3.2" // default parameter group!
   subnet_group_name    = "app-subnet-group"
   security_group_ids   = ["${aws_security_group.redis.id}"]
 }


### PR DESCRIPTION
Fix typo in aws_elasticache_cluster_default_parameter_group.md

I found the typo in 0.4.0 -> https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.4.0/docs/rules/aws_elasticache_cluster_default_parameter_group.md

However, part of it seems fixed already in master.