### PR TITLE
Add `RabbitMQ` to aws_mq_configuration_invalid_engine_type rule

### DIFF
--- a/rules/aws_mq_configuration_invalid_engine_type.go
+++ b/rules/aws_mq_configuration_invalid_engine_type.go
@@ -19,6 +19,7 @@ func NewAwsMqConfigurationInvalidEngineTypeRule() *AwsMqConfigurationInvalidEngi
 		attributeName: "engine_type",
 		enum: []string{
 			"ActiveMQ",
+			"RabbitMQ",
 		},
 	}
 }


### PR DESCRIPTION
Follow up of https://github.com/terraform-linters/tflint-ruleset-aws/pull/92