### PR TITLE
Add route target types for aws_route rules

### DIFF
--- a/docs/rules/aws_route_not_specified_target.md
+++ b/docs/rules/aws_route_not_specified_target.md
@@ -28,4 +28,4 @@ It results in an error.
 
 ## How To Fix
 
-Add a routing target. The [supported arguments](https://www.terraform.io/docs/providers/aws/r/route.html#argument-reference) are: `egress_only_gateway_id`, `gateway_id`, `instance_id`, `nat_gateway_id`, `network_interface_id`, `transit_gateway_id`, `vpc_peering_connection_id`.
+Add a routing target. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route#argument-reference

--- a/docs/rules/aws_route_specified_multiple_targets.md
+++ b/docs/rules/aws_route_specified_multiple_targets.md
@@ -30,12 +30,4 @@ It results in an error.
 
 ## How To Fix
 
-Check if two or more of the following attributes are specified:
-
-- gateway_id
-- egress_only_gateway_id
-- nat_gateway_id
-- instance_id
-- vpc_peering_connection_id
-- network_interface_id
-- transit_gateway_id
+Remove the other targets so that there is only one target. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route#argument-reference

--- a/rules/aws_route_not_specified_target.go
+++ b/rules/aws_route_not_specified_target.go
@@ -39,8 +39,7 @@ func (r *AwsRouteNotSpecifiedTargetRule) Link() string {
 	return project.ReferenceLink(r.Name())
 }
 
-// Check checks whether `gateway_id`, `egress_only_gateway_id`, `nat_gateway_id`, `instance_id`
-// `vpc_peering_connection_id`, `network_interface_id` or `vpc_endpoint_id`  is defined in a resource
+// Check checks whether a target is defined in a resource
 func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 	return runner.WalkResources(r.resourceType, func(resource *configs.Resource) error {
 		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
@@ -68,6 +67,12 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 				},
 				{
 					Name: "vpc_endpoint_id",
+				},
+				{
+					Name: "carrier_gateway_id",
+				},
+				{
+					Name: "local_gateway_id",
 				},
 			},
 		})

--- a/rules/aws_route_specified_multiple_targets.go
+++ b/rules/aws_route_specified_multiple_targets.go
@@ -39,8 +39,7 @@ func (r *AwsRouteSpecifiedMultipleTargetsRule) Link() string {
 	return project.ReferenceLink(r.Name())
 }
 
-// Check checks whether a resource defines `gateway_id`, `egress_only_gateway_id`, `nat_gateway_id`
-// `instance_id`, `vpc_peering_connection_id` or `network_interface_id` at the same time
+// Check checks whether a resource defines multiple targets
 func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner tflint.Runner) error {
 	return runner.WalkResources(r.resourceType, func(resource *configs.Resource) error {
 		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
@@ -65,6 +64,15 @@ func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner tflint.Runner) error
 				},
 				{
 					Name: "transit_gateway_id",
+				},
+				{
+					Name: "vpc_endpoint_id",
+				},
+				{
+					Name: "carrier_gateway_id",
+				},
+				{
+					Name: "local_gateway_id",
 				},
 			},
 		})


### PR DESCRIPTION
Added the following route target types:

- `carrier_gateway_id`
- `local_gateway_id`
- `vpc_endpoint_id` (only `aws_route_specified_multiple_targets`)