### PR TITLE
Fix false positive for IAM policy document without Sid

### DIFF
--- a/rules/aws_iam_policy_sid_invalid_characters.go
+++ b/rules/aws_iam_policy_sid_invalid_characters.go
@@ -3,10 +3,11 @@ package rules
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint-ruleset-aws/project"
-	"regexp"
 )
 
 type AwsIAMPolicySidInvalidCharactersStatementStruct struct {
@@ -65,7 +66,11 @@ func (r *AwsIAMPolicySidInvalidCharactersRule) Check(runner tflint.Runner) error
 
 		return runner.EnsureNoError(err, func() error {
 			for _, statement := range statements {
-				if r.validCharacters.MatchString(statement.Sid) == false {
+				if statement.Sid == "" {
+					continue
+				}
+
+				if !r.validCharacters.MatchString(statement.Sid) {
 					runner.EmitIssueOnExpr(
 						r,
 						fmt.Sprintf("The policy's sid (\"%s\") does not match \"%s\".", statement.Sid, r.validCharacters.String()),
@@ -75,6 +80,5 @@ func (r *AwsIAMPolicySidInvalidCharactersRule) Check(runner tflint.Runner) error
 			}
 			return nil
 		})
-		return nil
 	})
 }

--- a/rules/aws_iam_policy_sid_invalid_characters_test.go
+++ b/rules/aws_iam_policy_sid_invalid_characters_test.go
@@ -91,6 +91,30 @@ EOF
 				},
 			},
 		},
+		{
+			Name: "No Sid",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name = "test_policy"
+	role = "test_role"
+	policy = <<-EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::<bucketname>/*"
+    }
+  ]
+}
+EOF
+}
+`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewAwsIAMPolicySidInvalidCharactersRule()


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-ruleset-aws/issues/149#issuecomment-908876081

Probably, this is a valid case :)