### PR TITLE
Fix an error when policy is not evaluable

### DIFF
--- a/rules/aws_iam_policy_sid_invalid_characters.go
+++ b/rules/aws_iam_policy_sid_invalid_characters.go
@@ -58,13 +58,14 @@ func (r *AwsIAMPolicySidInvalidCharactersRule) Check(runner tflint.Runner) error
 	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
 		var val string
 		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
-		unMarshaledPolicy := AwsIAMPolicySidInvalidCharactersPolicyStruct{}
-		if jsonErr := json.Unmarshal([]byte(val), &unMarshaledPolicy); jsonErr != nil {
-			return jsonErr
-		}
-		statements := unMarshaledPolicy.Statement
 
 		return runner.EnsureNoError(err, func() error {
+			unMarshaledPolicy := AwsIAMPolicySidInvalidCharactersPolicyStruct{}
+			if jsonErr := json.Unmarshal([]byte(val), &unMarshaledPolicy); jsonErr != nil {
+				return jsonErr
+			}
+			statements := unMarshaledPolicy.Statement
+
 			for _, statement := range statements {
 				if statement.Sid == "" {
 					continue


### PR DESCRIPTION
Fixes #177 

`EvaluateExpr` does not update the passed value if the passed expression is not evaluable (e.g. unknown variables, data attributes, etc.). When this happens, `val` will be an empty string and the invalid value as JSON will be processed by `json.Unmarshal` and an error will occur.

To avoid this, refer to the evaluated result only in `EnsureError`. `EnsureError` does not raise this error because it simply does not execute the passed function if the expression cannot be evaluated.

FYI @Rihoj 