### PR TITLE
rules: Allow unbracketed IAM policy statements

### DIFF
--- a/rules/aws_iam_policy_sid_invalid_characters_test.go
+++ b/rules/aws_iam_policy_sid_invalid_characters_test.go
@@ -21,17 +21,17 @@ resource "aws_iam_policy" "policy" {
 	role = "test_role"
 	policy = <<-EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-	  {
-			"Sid": "This contains invalid-characters.",
-	    "Action": [
-	      "ec2:Describe*"
-			],
-			"Effect": "Allow",
-			"Resource": "arn:aws:s3:::<bucketname>/*"
-	  }
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "This contains invalid-characters.",
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::<bucketname>/*"
+    }
+  ]
 }
 EOF
 }
@@ -56,25 +56,25 @@ resource "aws_iam_policy" "policy2" {
 	role = "test_role"
 	policy = <<-EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-	  {
-			"Sid": "ThisIsAValidSid",
-	    "Action": [
-	      "ec2:Describe*"
-			],
-			"Effect": "Allow",
-			"Resource": "arn:aws:s3:::<bucketname>/*"
-	  },
-	  {
-			"Sid": "This contains invalid-characters.",
-	    "Action": [
-	      "ec2:Describe*"
-			],
-			"Effect": "Allow",
-			"Resource": "arn:aws:s3:::<bucketname>/*"
-	  }
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ThisIsAValidSid",
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::<bucketname>/*"
+    },
+    {
+      "Sid": "This contains invalid-characters.",
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::<bucketname>/*"
+    }
+  ]
 }
 EOF
 }
@@ -115,17 +115,42 @@ EOF
 `,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "Single Statement",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name = "test_policy"
+	role = "test_role"
+	policy = <<-EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Sid": "ThisIsAValidSid",
+    "Action": [
+      "ec2:Describe*"
+    ],
+    "Effect": "Allow",
+    "Resource": "arn:aws:s3:::<bucketname>/*"
+  }
+}
+EOF
+}
+`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewAwsIAMPolicySidInvalidCharactersRule()
 
 	for _, tc := range cases {
-		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		if err := rule.Check(runner); err != nil {
-			t.Fatalf("Unexpected error occurred: %s", err)
-		}
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
 
-		helper.AssertIssues(t, tc.Expected, runner.Issues)
+			helper.AssertIssues(t, tc.Expected, runner.Issues)
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/182