### PR TITLE
rules: Use EmitIssueOnExpr when emitting an issue for an expression

### DIFF
--- a/rules/aws_elasticache_cluster_previous_type.go
+++ b/rules/aws_elasticache_cluster_previous_type.go
@@ -71,10 +71,10 @@ func (r *AwsElastiCacheClusterPreviousTypeRule) Check(runner tflint.Runner) erro
 
 		return runner.EnsureNoError(err, func() error {
 			if r.previousNodeTypes[nodeType] {
-				runner.EmitIssue(
+				runner.EmitIssueOnExpr(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),
-					attribute.Expr.Range(),
+					attribute.Expr,
 				)
 			}
 			return nil

--- a/rules/aws_elasticache_replication_group_previous_type.go
+++ b/rules/aws_elasticache_replication_group_previous_type.go
@@ -71,10 +71,10 @@ func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Check(runner tflint.Run
 
 		return runner.EnsureNoError(err, func() error {
 			if r.previousNodeTypes[nodeType] {
-				runner.EmitIssue(
+				runner.EmitIssueOnExpr(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),
-					attribute.Expr.Range(),
+					attribute.Expr,
 				)
 			}
 			return nil

--- a/rules/aws_s3_bucket_name.go
+++ b/rules/aws_s3_bucket_name.go
@@ -70,20 +70,20 @@ func (r *AwsS3BucketNameRule) Check(runner tflint.Runner) error {
 		return runner.EnsureNoError(err, func() error {
 			if config.Prefix != "" {
 				if !strings.HasPrefix(name, config.Prefix) {
-					runner.EmitIssue(
+					runner.EmitIssueOnExpr(
 						r,
 						fmt.Sprintf(`Bucket name "%s" does not have prefix "%s"`, name, config.Prefix),
-						attribute.Expr.Range(),
+						attribute.Expr,
 					)
 				}
 			}
 
 			if config.Regex != "" {
 				if !regex.MatchString(name) {
-					runner.EmitIssue(
+					runner.EmitIssueOnExpr(
 						r,
 						fmt.Sprintf(`Bucket name "%s" does not match regex "%s"`, name, config.Regex),
-						attribute.Expr.Range(),
+						attribute.Expr,
 					)
 				}
 			}


### PR DESCRIPTION
EmitIssue is a low-level API that cannot send expression associations to the host process:
https://github.com/terraform-linters/tflint-plugin-sdk/blob/v0.9.1/tflint/client/client.go#L382-L388

As a result, the expression currently being processed cannot be recognized and issues encountered during module inspection are ignored. You should use `EmitIssueOnExpr` in this case:
https://github.com/terraform-linters/tflint-plugin-sdk/blob/v0.9.1/tflint/client/client.go#L365-L372
