### PR TITLE
Add `AWS_LAMBDA` as a valid Transfer Server identity provider type

### DIFF
--- a/rules/models/aws_transfer_server_invalid_identity_provider_type.go
+++ b/rules/models/aws_transfer_server_invalid_identity_provider_type.go
@@ -26,6 +26,7 @@ func NewAwsTransferServerInvalidIdentityProviderTypeRule() *AwsTransferServerInv
 			"SERVICE_MANAGED",
 			"API_GATEWAY",
 			"AWS_DIRECTORY_SERVICE",
+			"AWS_LAMBDA",
 		},
 	}
 }


### PR DESCRIPTION
Closes #206.