### PR TITLE
Updated missing documentation

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -17,7 +17,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_db_instance_invalid_parameter_group|Disallow using invalid parameter group|✔|✔|
 |[aws_db_instance_invalid_type](aws_db_instance_invalid_type.md)|Disallow using invalid instance class||✔|
 |aws_db_instance_invalid_vpc_security_group|Disallow using invalid VPC security groups|✔|✔|
-|aws_dynamodb_table_invalid_stream_view_type|||✔|
+|aws_dynamodb_table_invalid_stream_view_type|Disallow using invalid stream view types for DynamoDB||✔|
 |aws_elasticache_cluster_invalid_parameter_group|Disallow using invalid parameter group|✔|✔|
 |aws_elasticache_cluster_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elasticache_cluster_invalid_subnet_group|Disallow using invalid subnet group|✔|✔|
@@ -26,9 +26,9 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_elb_invalid_instance|Disallow using invalid instances|✔|✔|
 |aws_elb_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elb_invalid_subnet|Disallow using invalid subnets|✔|✔|
-|[aws_iam_group_policy_too_long](aws_iam_group_policy_too_long.md)|||✔|
-|[aws_iam_policy_sid_invalid_characters](aws_iam_policy_sid_invalid_characters.md)|||✔|
-|[aws_iam_policy_too_long_policy](aws_iam_policy_too_long_policy.md)|||✔|
+|[aws_iam_group_policy_too_long](aws_iam_group_policy_too_long.md)|Disallow IAM group policies that are too long||✔|
+|[aws_iam_policy_sid_invalid_characters](aws_iam_policy_sid_invalid_characters.md)|Disallow invalid characters in an IAM policy's SID||✔|
+|[aws_iam_policy_too_long_policy](aws_iam_policy_too_long_policy.md)|Disallow IAM group policies that are too long||✔|
 |aws_instance_invalid_ami|Disallow using invalid AMI|✔|✔|
 |aws_instance_invalid_iam_profile|Disallow using invalid IAM profile|✔|✔|
 |aws_instance_invalid_key_name|Disallow using invalid key name|✔|✔|
@@ -36,8 +36,8 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_instance_invalid_vpc_security_group|Disallow using invalid VPC security groups|✔|✔|
 |aws_launch_configuration_invalid_iam_profile|Disallow using invalid IAM profile|✔|✔|
 |aws_launch_configuration_invalid_image_id|Disallow using invalid image ID|✔|✔|
-|aws_mq_broker_invalid_engine_type|||✔|
-|aws_mq_configuration_invalid_engine_type|||✔|
+|aws_mq_broker_invalid_engine_type|Disallow invalid engine type for MQ Broker||✔|
+|aws_mq_configuration_invalid_engine_type|Disallow invalid engine type for MQ Configuration||✔|
 |aws_route_invalid_egress_only_gateway|Disallow using invalid egress only gateway|✔|✔|
 |aws_route_invalid_gateway|Disallow using invalid gateway|✔|✔|
 |aws_route_invalid_instance|Disallow using invalid instance|✔|✔|
@@ -47,9 +47,9 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_route_invalid_vpc_peering_connection|Disallow using invalid VPC peering connection|✔|✔|
 |[aws_route_not_specified_target](aws_route_not_specified_target.md)|Disallow routes that have no targets||✔|
 |[aws_route_specified_multiple_targets](aws_route_specified_multiple_targets.md)|Disallow routes that have multiple targets||✔|
-|aws_s3_bucket_invalid_acl|||✔|
-|aws_s3_bucket_invalid_region|||✔|
-|aws_spot_fleet_request_invalid_excess_capacity_termination_policy|||✔|
+|aws_s3_bucket_invalid_acl|Disallow invalid ACL rule for S3 bucket||✔|
+|aws_s3_bucket_invalid_region|Disallow invalid region for S3 bucket||✔|
+|aws_spot_fleet_request_invalid_excess_capacity_termination_policy|Disallow invalid excess capacity termination policy||✔|
 
 ### Best Practices/Naming Conventions
 
@@ -68,7 +68,7 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
-|[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)||✔|
+|[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)|Disallow deprecated runtimes for Lambda Function|✔|
 |[aws_resource_missing_tags](aws_resource_missing_tags.md)|Require specific tags for all AWS resource types that support them||
 |[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the specified naming rules||
 

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -17,7 +17,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_db_instance_invalid_parameter_group|Disallow using invalid parameter group|✔|✔|
 |[aws_db_instance_invalid_type](aws_db_instance_invalid_type.md)|Disallow using invalid instance class||✔|
 |aws_db_instance_invalid_vpc_security_group|Disallow using invalid VPC security groups|✔|✔|
-|aws_dynamodb_table_invalid_stream_view_type|||✔|
+|aws_dynamodb_table_invalid_stream_view_type|Disallow using invalid stream view types for DynamoDB||✔|
 |aws_elasticache_cluster_invalid_parameter_group|Disallow using invalid parameter group|✔|✔|
 |aws_elasticache_cluster_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elasticache_cluster_invalid_subnet_group|Disallow using invalid subnet group|✔|✔|
@@ -26,9 +26,9 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_elb_invalid_instance|Disallow using invalid instances|✔|✔|
 |aws_elb_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elb_invalid_subnet|Disallow using invalid subnets|✔|✔|
-|[aws_iam_group_policy_too_long](aws_iam_group_policy_too_long.md)|||✔|
-|[aws_iam_policy_sid_invalid_characters](aws_iam_policy_sid_invalid_characters.md)|||✔|
-|[aws_iam_policy_too_long_policy](aws_iam_policy_too_long_policy.md)|||✔|
+|[aws_iam_group_policy_too_long](aws_iam_group_policy_too_long.md)|Disallow IAM group policies that are too long||✔|
+|[aws_iam_policy_sid_invalid_characters](aws_iam_policy_sid_invalid_characters.md)|Dissallow invalid characters in an IAM policy's SID||✔|
+|[aws_iam_policy_too_long_policy](aws_iam_policy_too_long_policy.md)|Disallow IAM group policies that are too long||✔|
 |aws_instance_invalid_ami|Disallow using invalid AMI|✔|✔|
 |aws_instance_invalid_iam_profile|Disallow using invalid IAM profile|✔|✔|
 |aws_instance_invalid_key_name|Disallow using invalid key name|✔|✔|
@@ -36,8 +36,8 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_instance_invalid_vpc_security_group|Disallow using invalid VPC security groups|✔|✔|
 |aws_launch_configuration_invalid_iam_profile|Disallow using invalid IAM profile|✔|✔|
 |aws_launch_configuration_invalid_image_id|Disallow using invalid image ID|✔|✔|
-|aws_mq_broker_invalid_engine_type|||✔|
-|aws_mq_configuration_invalid_engine_type|||✔|
+|aws_mq_broker_invalid_engine_type|Disallow invalid engine type for MQ Broker||✔|
+|aws_mq_configuration_invalid_engine_type|Disallow  invalid engine type for MQ Configuration||✔|
 |aws_route_invalid_egress_only_gateway|Disallow using invalid egress only gateway|✔|✔|
 |aws_route_invalid_gateway|Disallow using invalid gateway|✔|✔|
 |aws_route_invalid_instance|Disallow using invalid instance|✔|✔|
@@ -47,9 +47,9 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_route_invalid_vpc_peering_connection|Disallow using invalid VPC peering connection|✔|✔|
 |[aws_route_not_specified_target](aws_route_not_specified_target.md)|Disallow routes that have no targets||✔|
 |[aws_route_specified_multiple_targets](aws_route_specified_multiple_targets.md)|Disallow routes that have multiple targets||✔|
-|aws_s3_bucket_invalid_acl|||✔|
-|aws_s3_bucket_invalid_region|||✔|
-|aws_spot_fleet_request_invalid_excess_capacity_termination_policy|||✔|
+|aws_s3_bucket_invalid_acl|Disallow invalid ACL rule for S3 bucket||✔|
+|aws_s3_bucket_invalid_region|Disallow invalid region for S3 bucket||✔|
+|aws_spot_fleet_request_invalid_excess_capacity_termination_policy|Disallow invalid excess capacity termination policy||✔|
 
 ### Best Practices/Naming Conventions
 
@@ -68,7 +68,7 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
-|[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)||✔|
+|[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)|Disallow deprecated runtimes for Lambda Function|✔|
 |[aws_resource_missing_tags](aws_resource_missing_tags.md)|Require specific tags for all AWS resource types that support them||
 |[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the specified naming rules||
 

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -27,7 +27,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_elb_invalid_security_group|Disallow using invalid security groups|✔|✔|
 |aws_elb_invalid_subnet|Disallow using invalid subnets|✔|✔|
 |[aws_iam_group_policy_too_long](aws_iam_group_policy_too_long.md)|Disallow IAM group policies that are too long||✔|
-|[aws_iam_policy_sid_invalid_characters](aws_iam_policy_sid_invalid_characters.md)|Dissallow invalid characters in an IAM policy's SID||✔|
+|[aws_iam_policy_sid_invalid_characters](aws_iam_policy_sid_invalid_characters.md)|Disallow invalid characters in an IAM policy's SID||✔|
 |[aws_iam_policy_too_long_policy](aws_iam_policy_too_long_policy.md)|Disallow IAM group policies that are too long||✔|
 |aws_instance_invalid_ami|Disallow using invalid AMI|✔|✔|
 |aws_instance_invalid_iam_profile|Disallow using invalid IAM profile|✔|✔|

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -37,7 +37,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_launch_configuration_invalid_iam_profile|Disallow using invalid IAM profile|✔|✔|
 |aws_launch_configuration_invalid_image_id|Disallow using invalid image ID|✔|✔|
 |aws_mq_broker_invalid_engine_type|Disallow invalid engine type for MQ Broker||✔|
-|aws_mq_configuration_invalid_engine_type|Disallow  invalid engine type for MQ Configuration||✔|
+|aws_mq_configuration_invalid_engine_type|Disallow invalid engine type for MQ Configuration||✔|
 |aws_route_invalid_egress_only_gateway|Disallow using invalid egress only gateway|✔|✔|
 |aws_route_invalid_gateway|Disallow using invalid gateway|✔|✔|
 |aws_route_invalid_instance|Disallow using invalid instance|✔|✔|


### PR DESCRIPTION
Updated missing documentation to fix terraform-linters/tflint-ruleset-aws#229

To be honest, writing these out felt redundant given the names of the policies, and some of them having a linked documentation. I also apologize for the ones I added on this.

If these descriptions don't fit well enough just let me know.