### PR TITLE
refactor previous generation instance type rules

### DIFF
--- a/rules/aws_db_instance_previous_type.go
+++ b/rules/aws_db_instance_previous_type.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+        "strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -21,24 +22,12 @@ func NewAwsDBInstancePreviousTypeRule() *AwsDBInstancePreviousTypeRule {
 		resourceType:  "aws_db_instance",
 		attributeName: "instance_class",
 		previousInstanceTypes: map[string]bool{
-			"db.t1.micro":    true,
-			"db.m1.small":    true,
-			"db.m1.medium":   true,
-			"db.m1.large":    true,
-			"db.m1.xlarge":   true,
-			"db.m2.xlarge":   true,
-			"db.m2.2xlarge":  true,
-			"db.m2.4xlarge":  true,
-			"db.m3.medium":   true,
-			"db.m3.large":    true,
-			"db.m3.xlarge":   true,
-			"db.m3.2xlarge":  true,
-			"db.r3.large":    true,
-			"db.r3.xlarge":   true,
-			"db.r3.2xlarge":  true,
-			"db.r3.4xlarge":  true,
-			"db.r3.8xlarge":  true,
-			"db.cr1.8xlarge": true,
+			"cr1": true,
+			"m1":  true,
+			"m2":  true,
+			"m3":  true,
+			"r3":  true,
+			"t1":  true,
 		},
 	}
 }
@@ -70,7 +59,7 @@ func (r *AwsDBInstancePreviousTypeRule) Check(runner tflint.Runner) error {
 		err := runner.EvaluateExpr(attribute.Expr, &instanceType, nil)
 
 		return runner.EnsureNoError(err, func() error {
-			if r.previousInstanceTypes[instanceType] {
+			if r.previousInstanceTypes[strings.Split(instanceType, ".")[1]] {
 				runner.EmitIssueOnExpr(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),

--- a/rules/aws_elasticache_cluster_previous_type.go
+++ b/rules/aws_elasticache_cluster_previous_type.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -49,7 +50,7 @@ func (r *AwsElastiCacheClusterPreviousTypeRule) Check(runner tflint.Runner) erro
 		err := runner.EvaluateExpr(attribute.Expr, &nodeType, nil)
 
 		return runner.EnsureNoError(err, func() error {
-			if previousElastiCacheNodeTypes[nodeType] {
+			if previousElastiCacheNodeTypes[strings.Split(nodeType, ".")[1]] {
 				runner.EmitIssueOnExpr(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),

--- a/rules/aws_elasticache_replication_group_previous_type.go
+++ b/rules/aws_elasticache_replication_group_previous_type.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -49,7 +50,7 @@ func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Check(runner tflint.Run
 		err := runner.EvaluateExpr(attribute.Expr, &nodeType, nil)
 
 		return runner.EnsureNoError(err, func() error {
-			if previousElastiCacheNodeTypes[nodeType] {
+			if previousElastiCacheNodeTypes[strings.Split(nodeType, ".")[1]] {
 				runner.EmitIssueOnExpr(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),

--- a/rules/aws_instance_previous_type.go
+++ b/rules/aws_instance_previous_type.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+        "strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -21,41 +22,21 @@ func NewAwsInstancePreviousTypeRule() *AwsInstancePreviousTypeRule {
 		resourceType:  "aws_instance",
 		attributeName: "instance_type",
 		previousInstanceTypes: map[string]bool{
-			"t1.micro":    true,
-			"m1.small":    true,
-			"m1.medium":   true,
-			"m1.large":    true,
-			"m1.xlarge":   true,
-			"m3.medium":   true,
-			"m3.large":    true,
-			"m3.xlarge":   true,
-			"m3.2xlarge":  true,
-			"c1.medium":   true,
-			"c1.xlarge":   true,
-			"cc2.8xlarge": true,
-			"cg1.4xlarge": true,
-			"c3.large":    true,
-			"c3.xlarge":   true,
-			"c3.2xlarge":  true,
-			"c3.4xlarge":  true,
-			"c3.8xlarge":  true,
-			"g2.2xlarge":  true,
-			"g2.8xlarge":  true,
-			"m2.xlarge":   true,
-			"m2.2xlarge":  true,
-			"m2.4xlarge":  true,
-			"cr1.8xlarge": true,
-			"r3.large":    true,
-			"r3.xlarge":   true,
-			"r3.2xlarge":  true,
-			"r3.4xlarge":  true,
-			"r3.8xlarge":  true,
-			"i2.xlarge":   true,
-			"i2.2xlarge":  true,
-			"i2.4xlarge":  true,
-			"i2.8xlarge":  true,
-			"hi1.4xlarge": true,
-			"hs1.8xlarge": true,
+			"c1":  true,
+			"c2":  true,
+			"c3":  true,
+			"cc2": true,
+			"cg1": true,
+			"cr1": true,
+			"g2":  true,
+			"hi1": true,
+			"hs1": true,
+			"i2":  true,
+			"m1":  true,
+			"m2":  true,
+			"m3":  true,
+			"r3":  true,
+			"t1":  true,			
 		},
 	}
 }
@@ -87,7 +68,7 @@ func (r *AwsInstancePreviousTypeRule) Check(runner tflint.Runner) error {
 		err := runner.EvaluateExpr(attribute.Expr, &instanceType, nil)
 
 		return runner.EnsureNoError(err, func() error {
-			if r.previousInstanceTypes[instanceType] {
+			if r.previousInstanceTypes[strings.Split(instanceType, ".")[0]] {
 				runner.EmitIssueOnExpr(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -76,22 +76,10 @@ var validElastiCacheNodeTypes = map[string]bool{
 
 var previousElastiCacheNodeTypes = map[string]bool{
 	// https://aws.amazon.com/elasticache/previous-generation/?nc1=h_ls
-	"cache.m1.small":   true,
-	"cache.m1.medium":  true,
-	"cache.m1.large":   true,
-	"cache.m1.xlarge":  true,
-	"cache.m2.xlarge":  true,
-	"cache.m2.2xlarge": true,
-	"cache.m2.4xlarge": true,
-	"cache.m3.medium":  true,
-	"cache.m3.large":   true,
-	"cache.m3.xlarge":  true,
-	"cache.m3.2xlarge": true,
-	"cache.r3.large":   true,
-	"cache.r3.xlarge":  true,
-	"cache.r3.2xlarge": true,
-	"cache.r3.4xlarge": true,
-	"cache.r3.8xlarge": true,
-	"cache.c1.xlarge":  true,
-	"cache.t1.micro":   true,
+	"c1": true,
+	"m1": true,
+	"m2": true,
+	"m3": true,
+	"r3": true,
+	"t1": true,
 }


### PR DESCRIPTION
https://github.com/terraform-linters/tflint-ruleset-aws/pull/214#discussion_r774801889

https://aws.amazon.com/ec2/previous-generation/
https://aws.amazon.com/rds/previous-generation/
https://aws.amazon.com/elasticache/previous-generation/

---

added `c2` to `ec2` rule