### PR TITLE
Call EnsureNoError after evaluating `aws_route` expression so unevaluable expressions are skipped

### DIFF
--- a/rules/aws_route_not_specified_target.go
+++ b/rules/aws_route_not_specified_target.go
@@ -66,12 +66,14 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 		for _, attribute := range resource.Body.Attributes {
 			var val cty.Value
 			err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+			err = runner.EnsureNoError(err, func() error {
+				if val.IsNull() {
+					nullAttributes = nullAttributes + 1
+				}
+				return nil
+			})
 			if err != nil {
 				return err
-			}
-
-			if val.IsNull() {
-				nullAttributes = nullAttributes + 1
 			}
 		}
 


### PR DESCRIPTION
`runner.EvaluateExpr` can return errors that are skippable (for example, `ErrUnevaluable` which occurs when an expression cannot be evaluated) and entirely normal.

For example, the snippet
```terraform
data "aws_transit_gateway" "tgw" {
  tags = {
    Name = "Transit Gateway"
  }
}

resource "aws_route" "tgw_route" {
  route_table_id     = "rtb-1234abcd"
  transit_gateway_id = data.aws_transit_gateway_id.tgw.id
}
```
Will produce the error:
```
Failed to check ruleset; Failed to check `aws_route_not_specified_target` rule: unevaluable expression found in example.tf:9
```
when the terraform is perfectly valid (and obeys the rule).

This PR just wraps the `IsNull` increment in a `runner.EnsureNoError` call so that skippable errors are skippable.