### PR TITLE
Fix rule template for rule generator

### DIFF
--- a/rules/provider.go
+++ b/rules/provider.go
@@ -6,49 +6,45 @@ import (
 	"github.com/terraform-linters/tflint-ruleset-aws/rules/models"
 )
 
-var rules = [][]tflint.Rule{
-	[]tflint.Rule{
-		NewAwsDBInstanceDefaultParameterGroupRule(),
-		NewAwsDBInstanceInvalidEngineRule(),
-		NewAwsDBInstanceInvalidTypeRule(),
-		NewAwsDBInstancePreviousTypeRule(),
-		NewAwsDynamoDBTableInvalidStreamViewTypeRule(),
-		NewAwsElastiCacheClusterDefaultParameterGroupRule(),
-		NewAwsElastiCacheClusterInvalidTypeRule(),
-		NewAwsElastiCacheClusterPreviousTypeRule(),
-		NewAwsIAMPolicyDocumentGovFriendlyArnsRule(),
-		NewAwsIAMPolicyGovFriendlyArnsRule(),
-		NewAwsIAMRolePolicyGovFriendlyArnsRule(),
-		NewAwsInstancePreviousTypeRule(),
-		NewAwsMqBrokerInvalidEngineTypeRule(),
-		NewAwsMqConfigurationInvalidEngineTypeRule(),
-		NewAwsResourceMissingTagsRule(),
-		NewAwsRouteNotSpecifiedTargetRule(),
-		NewAwsRouteSpecifiedMultipleTargetsRule(),
-		NewAwsS3BucketInvalidACLRule(),
-		NewAwsS3BucketInvalidRegionRule(),
-		NewAwsS3BucketNameRule(),
-		NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
-		NewAwsAPIGatewayModelInvalidNameRule(),
-		NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
-		NewAwsElastiCacheReplicationGroupInvalidTypeRule(),
-		NewAwsElastiCacheReplicationGroupPreviousTypeRule(),
-		NewAwsIAMPolicySidInvalidCharactersRule(),
-		NewAwsIAMPolicyTooLongPolicyRule(),
-		NewAwsLambdaFunctionDeprecatedRuntimeRule(),
-		NewAwsIAMGroupPolicyTooLongRule(),
-		NewAwsAcmCertificateLifecycleRule(),
-		NewAwsElasticBeanstalkEnvironmentInvalidNameFormatRule(),
-	},
-	models.Rules,
-	api.Rules,
+var manualRules = []tflint.Rule{
+	NewAwsDBInstanceDefaultParameterGroupRule(),
+	NewAwsDBInstanceInvalidEngineRule(),
+	NewAwsDBInstanceInvalidTypeRule(),
+	NewAwsDBInstancePreviousTypeRule(),
+	NewAwsDynamoDBTableInvalidStreamViewTypeRule(),
+	NewAwsElastiCacheClusterDefaultParameterGroupRule(),
+	NewAwsElastiCacheClusterInvalidTypeRule(),
+	NewAwsElastiCacheClusterPreviousTypeRule(),
+	NewAwsIAMPolicyDocumentGovFriendlyArnsRule(),
+	NewAwsIAMPolicyGovFriendlyArnsRule(),
+	NewAwsIAMRolePolicyGovFriendlyArnsRule(),
+	NewAwsInstancePreviousTypeRule(),
+	NewAwsMqBrokerInvalidEngineTypeRule(),
+	NewAwsMqConfigurationInvalidEngineTypeRule(),
+	NewAwsResourceMissingTagsRule(),
+	NewAwsRouteNotSpecifiedTargetRule(),
+	NewAwsRouteSpecifiedMultipleTargetsRule(),
+	NewAwsS3BucketInvalidACLRule(),
+	NewAwsS3BucketInvalidRegionRule(),
+	NewAwsS3BucketNameRule(),
+	NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
+	NewAwsAPIGatewayModelInvalidNameRule(),
+	NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
+	NewAwsElastiCacheReplicationGroupInvalidTypeRule(),
+	NewAwsElastiCacheReplicationGroupPreviousTypeRule(),
+	NewAwsIAMPolicySidInvalidCharactersRule(),
+	NewAwsIAMPolicyTooLongPolicyRule(),
+	NewAwsLambdaFunctionDeprecatedRuntimeRule(),
+	NewAwsIAMGroupPolicyTooLongRule(),
+	NewAwsAcmCertificateLifecycleRule(),
+	NewAwsElasticBeanstalkEnvironmentInvalidNameFormatRule(),
 }
 
 // Rules is a list of all rules
 var Rules []tflint.Rule
 
 func init() {
-	for _, r := range rules {
-		Rules = append(Rules, r...)
-	}
+	Rules = append(Rules, manualRules...)
+	Rules = append(Rules, models.Rules...)
+	Rules = append(Rules, api.Rules...)
 }

--- a/rules/rule.go.tmpl
+++ b/rules/rule.go.tmpl
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint-ruleset-aws/project"
 )
@@ -9,6 +9,8 @@ import (
 // TODO: Write the rule's description here
 // {{ .RuleNameCC }}Rule checks ...
 type {{ .RuleNameCC }}Rule struct {
+	tflint.DefaultRule
+
 	resourceType  string
 	attributeName string
 }
@@ -51,19 +53,38 @@ func (r *{{ .RuleNameCC }}Rule) Check(runner tflint.Runner) error {
 	// TODO: Write the implementation here. See this documentation for what tflint.Runner can do.
 	//       https://pkg.go.dev/github.com/terraform-linters/tflint-plugin-sdk/tflint#Runner
 
-	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.attributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
 		var val string
 		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
 
-		return runner.EnsureNoError(err, func() error {
+		err = runner.EnsureNoError(err, func() error {
 			if val == "" {
-				runner.EmitIssueOnExpr(
+				runner.EmitIssue(
 					r,
 					"TODO",
-					attribute.Expr,
+					attribute.Expr.Range(),
 				)
 			}
 			return nil
 		})
-	})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
The rules generated by `go run ./rules/generator` are based on the old SDK's API and now fail to build. This PR fixes the template so that the build can succeed.