### PR TITLE
style: format rules/api/rule.go.tmpl and run `go generate ./...`

### DIFF
--- a/rules/api/aws_alb_invalid_security_group.go
+++ b/rules/api/aws_alb_invalid_security_group.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsALBInvalidSecurityGroupRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsALBInvalidSecurityGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSecurityGroups
 func (r *AwsALBInvalidSecurityGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_alb_invalid_subnet.go
+++ b/rules/api/aws_alb_invalid_subnet.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsALBInvalidSubnetRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsALBInvalidSubnetRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSubnets
 func (r *AwsALBInvalidSubnetRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_db_instance_invalid_db_subnet_group.go
+++ b/rules/api/aws_db_instance_invalid_db_subnet_group.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsDBInstanceInvalidDBSubnetGroupRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsDBInstanceInvalidDBSubnetGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeDBSubnetGroups
 func (r *AwsDBInstanceInvalidDBSubnetGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_db_instance_invalid_option_group.go
+++ b/rules/api/aws_db_instance_invalid_option_group.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsDBInstanceInvalidOptionGroupRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsDBInstanceInvalidOptionGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeOptionGroups
 func (r *AwsDBInstanceInvalidOptionGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_db_instance_invalid_parameter_group.go
+++ b/rules/api/aws_db_instance_invalid_parameter_group.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsDBInstanceInvalidParameterGroupRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsDBInstanceInvalidParameterGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeDBParameterGroups
 func (r *AwsDBInstanceInvalidParameterGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_db_instance_invalid_vpc_security_group.go
+++ b/rules/api/aws_db_instance_invalid_vpc_security_group.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsDBInstanceInvalidVpcSecurityGroupRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsDBInstanceInvalidVpcSecurityGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSecurityGroups
 func (r *AwsDBInstanceInvalidVpcSecurityGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elasticache_cluster_invalid_parameter_group.go
+++ b/rules/api/aws_elasticache_cluster_invalid_parameter_group.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsElastiCacheClusterInvalidParameterGroupRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsElastiCacheClusterInvalidParameterGroupRule) Metadata() interface{} 
 
 // Check checks whether the attributes are included in the list retrieved by DescribeCacheParameterGroups
 func (r *AwsElastiCacheClusterInvalidParameterGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elasticache_cluster_invalid_security_group.go
+++ b/rules/api/aws_elasticache_cluster_invalid_security_group.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsElastiCacheClusterInvalidSecurityGroupRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsElastiCacheClusterInvalidSecurityGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSecurityGroups
 func (r *AwsElastiCacheClusterInvalidSecurityGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elasticache_cluster_invalid_subnet_group.go
+++ b/rules/api/aws_elasticache_cluster_invalid_subnet_group.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsElastiCacheClusterInvalidSubnetGroupRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsElastiCacheClusterInvalidSubnetGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeCacheSubnetGroups
 func (r *AwsElastiCacheClusterInvalidSubnetGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elasticache_replication_group_invalid_parameter_group.go
+++ b/rules/api/aws_elasticache_replication_group_invalid_parameter_group.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsElastiCacheReplicationGroupInvalidParameterGroupRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsElastiCacheReplicationGroupInvalidParameterGroupRule) Metadata() int
 
 // Check checks whether the attributes are included in the list retrieved by DescribeCacheParameterGroups
 func (r *AwsElastiCacheReplicationGroupInvalidParameterGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elasticache_replication_group_invalid_security_group.go
+++ b/rules/api/aws_elasticache_replication_group_invalid_security_group.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsElastiCacheReplicationGroupInvalidSecurityGroupRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsElastiCacheReplicationGroupInvalidSecurityGroupRule) Metadata() inte
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSecurityGroups
 func (r *AwsElastiCacheReplicationGroupInvalidSecurityGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elasticache_replication_group_invalid_subnet_group.go
+++ b/rules/api/aws_elasticache_replication_group_invalid_subnet_group.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsElastiCacheReplicationGroupInvalidSubnetGroupRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsElastiCacheReplicationGroupInvalidSubnetGroupRule) Metadata() interf
 
 // Check checks whether the attributes are included in the list retrieved by DescribeCacheSubnetGroups
 func (r *AwsElastiCacheReplicationGroupInvalidSubnetGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elb_invalid_instance.go
+++ b/rules/api/aws_elb_invalid_instance.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsELBInvalidInstanceRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsELBInvalidInstanceRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeInstances
 func (r *AwsELBInvalidInstanceRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elb_invalid_security_group.go
+++ b/rules/api/aws_elb_invalid_security_group.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsELBInvalidSecurityGroupRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsELBInvalidSecurityGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSecurityGroups
 func (r *AwsELBInvalidSecurityGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_elb_invalid_subnet.go
+++ b/rules/api/aws_elb_invalid_subnet.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsELBInvalidSubnetRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsELBInvalidSubnetRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSubnets
 func (r *AwsELBInvalidSubnetRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_instance_invalid_iam_profile.go
+++ b/rules/api/aws_instance_invalid_iam_profile.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsInstanceInvalidIAMProfileRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsInstanceInvalidIAMProfileRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by ListInstanceProfiles
 func (r *AwsInstanceInvalidIAMProfileRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_instance_invalid_key_name.go
+++ b/rules/api/aws_instance_invalid_key_name.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsInstanceInvalidKeyNameRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsInstanceInvalidKeyNameRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeKeyPairs
 func (r *AwsInstanceInvalidKeyNameRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_instance_invalid_subnet.go
+++ b/rules/api/aws_instance_invalid_subnet.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsInstanceInvalidSubnetRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsInstanceInvalidSubnetRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSubnets
 func (r *AwsInstanceInvalidSubnetRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_instance_invalid_vpc_security_group.go
+++ b/rules/api/aws_instance_invalid_vpc_security_group.go
@@ -5,10 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
+
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsInstanceInvalidVpcSecurityGroupRule checks whether attribute value actually exists
@@ -58,7 +59,7 @@ func (r *AwsInstanceInvalidVpcSecurityGroupRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeSecurityGroups
 func (r *AwsInstanceInvalidVpcSecurityGroupRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_launch_configuration_invalid_iam_profile.go
+++ b/rules/api/aws_launch_configuration_invalid_iam_profile.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsLaunchConfigurationInvalidIAMProfileRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsLaunchConfigurationInvalidIAMProfileRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by ListInstanceProfiles
 func (r *AwsLaunchConfigurationInvalidIAMProfileRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_route_invalid_egress_only_gateway.go
+++ b/rules/api/aws_route_invalid_egress_only_gateway.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsRouteInvalidEgressOnlyGatewayRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsRouteInvalidEgressOnlyGatewayRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeEgressOnlyInternetGateways
 func (r *AwsRouteInvalidEgressOnlyGatewayRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_route_invalid_gateway.go
+++ b/rules/api/aws_route_invalid_gateway.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsRouteInvalidGatewayRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsRouteInvalidGatewayRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeInternetGateways
 func (r *AwsRouteInvalidGatewayRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_route_invalid_instance.go
+++ b/rules/api/aws_route_invalid_instance.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsRouteInvalidInstanceRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsRouteInvalidInstanceRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeInstances
 func (r *AwsRouteInvalidInstanceRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_route_invalid_nat_gateway.go
+++ b/rules/api/aws_route_invalid_nat_gateway.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsRouteInvalidNatGatewayRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsRouteInvalidNatGatewayRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeNatGateways
 func (r *AwsRouteInvalidNatGatewayRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_route_invalid_network_interface.go
+++ b/rules/api/aws_route_invalid_network_interface.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsRouteInvalidNetworkInterfaceRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsRouteInvalidNetworkInterfaceRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeNetworkInterfaces
 func (r *AwsRouteInvalidNetworkInterfaceRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_route_invalid_route_table.go
+++ b/rules/api/aws_route_invalid_route_table.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsRouteInvalidRouteTableRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsRouteInvalidRouteTableRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeRouteTables
 func (r *AwsRouteInvalidRouteTableRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/aws_route_invalid_vpc_peering_connection.go
+++ b/rules/api/aws_route_invalid_vpc_peering_connection.go
@@ -5,9 +5,10 @@ package api
 import (
 	"fmt"
 	"log"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // AwsRouteInvalidVpcPeeringConnectionRule checks whether attribute value actually exists
@@ -57,7 +58,7 @@ func (r *AwsRouteInvalidVpcPeeringConnectionRule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by DescribeVpcPeeringConnections
 func (r *AwsRouteInvalidVpcPeeringConnectionRule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{

--- a/rules/api/rule.go.tmpl
+++ b/rules/api/rule.go.tmpl
@@ -5,13 +5,11 @@ package api
 import (
 	"fmt"
 	"log"
-
-{{- if eq .DataType "list" }}
-	hcl "github.com/hashicorp/hcl/v2"
-{{- end }}
+{{if eq .DataType "list"}}
+	hcl "github.com/hashicorp/hcl/v2"{{ end }}
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
-    "github.com/terraform-linters/tflint-ruleset-aws/aws"
+	"github.com/terraform-linters/tflint-ruleset-aws/aws"
 )
 
 // {{ .RuleNameCC }}Rule checks whether attribute value actually exists
@@ -61,7 +59,7 @@ func (r *{{ .RuleNameCC }}Rule) Metadata() interface{} {
 
 // Check checks whether the attributes are included in the list retrieved by {{ .ActionName }}
 func (r *{{ .RuleNameCC }}Rule) Check(rr tflint.Runner) error {
-    runner := rr.(*aws.Runner)
+	runner := rr.(*aws.Runner)
 
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{


### PR DESCRIPTION
Format `format rules/api/rule.go.tmpl` and run `go generate ./...`.

```console
$ go generate ./...
```

Fix the indent.