### PR TITLE
feat: add aws_db_proxy_invalid_max_idle_connections rule

### DIFF
--- a/docs/rules/aws_db_proxy_invalid_max_idle_connections.md
+++ b/docs/rules/aws_db_proxy_invalid_max_idle_connections.md
@@ -1,0 +1,33 @@
+# aws_db_proxy_invalid_max_idle_connections
+
+Disallow invalid `max_idle_connections_percent`.
+
+## Example
+
+```hcl
+resource "aws_db_proxy_default_target_group" "example" {
+  connection_pool_config {
+    max_connections_percent      = 10
+    max_idle_connections_percent = 50
+  }
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: max_idle_connections_percent 50 must be less than max_connections_percent 10 (aws_db_proxy_invalid_max_idle_connections)
+
+  on resource.tf line 4:
+   4:     max_idle_connections_percent = 50
+ 
+```
+
+## Why
+
+Apply will fail. (Plan will succeed with the invalid value though)
+
+## How To Fix
+
+Set `max_idle_connections_percent` to the value less than `max_connections_percent` according to the [document](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ConnectionPoolConfiguration.html).

--- a/rules/aws_db_proxy_invalid_max_idle_connections.go
+++ b/rules/aws_db_proxy_invalid_max_idle_connections.go
@@ -1,0 +1,101 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsDBProxyInvalidMaxIdleConnectionsRule checks whether the resource has invalid max_idle_connections_percent.
+type AwsDBProxyInvalidMaxIdleConnectionsRule struct {
+	tflint.DefaultRule
+
+	resourceType     string
+	blockType        string
+	attrMaxConns     string
+	attrMaxIdleConns string
+}
+
+// NewAwsDBProxyInvalidMaxIdleConnectionsRule returns new rule with default attributes
+func NewAwsDBProxyInvalidMaxIdleConnectionsRule() *AwsDBProxyInvalidMaxIdleConnectionsRule {
+	return &AwsDBProxyInvalidMaxIdleConnectionsRule{
+		resourceType:     "aws_db_proxy_default_target_group",
+		blockType:        "connection_pool_config",
+		attrMaxConns:     "max_connections_percent",
+		attrMaxIdleConns: "max_idle_connections_percent",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBProxyInvalidMaxIdleConnectionsRule) Name() string {
+	return "aws_db_proxy_invalid_max_idle_connections"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBProxyInvalidMaxIdleConnectionsRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsDBProxyInvalidMaxIdleConnectionsRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsDBProxyInvalidMaxIdleConnectionsRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether the resource has invalid max_idle_connections_percent.
+func (r *AwsDBProxyInvalidMaxIdleConnectionsRule) Check(runner tflint.Runner) error {
+	bodySchema := &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type: r.blockType,
+				Body: &hclext.BodySchema{
+					Attributes: []hclext.AttributeSchema{
+						{
+							Name: r.attrMaxConns,
+						},
+						{
+							Name: r.attrMaxIdleConns,
+						},
+					},
+				},
+			},
+		},
+	}
+	resources, err := runner.GetResourceContent(r.resourceType, bodySchema, nil)
+	if err != nil {
+		return err
+	}
+	for _, resource := range resources.Blocks {
+		for _, block := range resource.Body.Blocks {
+			if block.Type != r.blockType {
+				continue
+			}
+			attrMaxConns, existsMaxConns := block.Body.Attributes[r.attrMaxConns]
+			attrMaxIdleConns, existsMaxIdleConns := block.Body.Attributes[r.attrMaxIdleConns]
+			if !(existsMaxConns && existsMaxIdleConns) {
+				continue
+			}
+			var (
+				maxConns     int
+				maxIdleConns int
+			)
+			if err := runner.EvaluateExpr(attrMaxConns.Expr, &maxConns, nil); err != nil {
+				return err
+			}
+			if err := runner.EvaluateExpr(attrMaxIdleConns.Expr, &maxIdleConns, nil); err != nil {
+				return err
+			}
+			if maxIdleConns > maxConns {
+				msg := fmt.Sprintf("%s %d must be less than %s %d", r.attrMaxIdleConns, maxIdleConns, r.attrMaxConns, maxConns)
+				runner.EmitIssue(r, msg, attrMaxIdleConns.Range)
+			}
+		}
+	}
+	return nil
+}

--- a/rules/aws_db_proxy_invalid_max_idle_connections_test.go
+++ b/rules/aws_db_proxy_invalid_max_idle_connections_test.go
@@ -1,0 +1,63 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsDBProxyInvalidMaxIdleConnections(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "equal",
+			Content: `
+resource "aws_db_proxy_default_target_group" "example" {
+  connection_pool_config {
+    max_connections_percent      = 50
+    max_idle_connections_percent = 50
+  }
+}
+                        `,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "max_idle_connections_percent grater than max_connections_percent",
+			Content: `
+resource "aws_db_proxy_default_target_group" "example" {
+  connection_pool_config {
+    max_connections_percent      = 10
+    max_idle_connections_percent = 50
+  }
+}
+                        `,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsDBProxyInvalidMaxIdleConnectionsRule(),
+					Message: "max_idle_connections_percent 50 must be less than max_connections_percent 10",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 5, Column: 5},
+						End:      hcl.Pos{Line: 5, Column: 38},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsDBProxyInvalidMaxIdleConnectionsRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -38,6 +38,7 @@ var manualRules = []tflint.Rule{
 	NewAwsIAMGroupPolicyTooLongRule(),
 	NewAwsAcmCertificateLifecycleRule(),
 	NewAwsElasticBeanstalkEnvironmentInvalidNameFormatRule(),
+	NewAwsDBProxyInvalidMaxIdleConnectionsRule(),
 }
 
 // Rules is a list of all rules


### PR DESCRIPTION
Add `aws_db_proxy_invalid_max_idle_connections` rule that checks whether `max_idle_connections_percent` less than `max_connections_percent`.