### PR TITLE
Add aws_security_group_rule_invalid_protocol rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -51,6 +51,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_s3_bucket_invalid_acl|Disallow invalid ACL rule for S3 bucket||✔|
 |aws_s3_bucket_invalid_region|Disallow invalid region for S3 bucket||✔|
 |aws_spot_fleet_request_invalid_excess_capacity_termination_policy|Disallow invalid excess capacity termination policy||✔|
+|[aws_security_group_rule_invalid_protocol](aws_security_group_rule_invalid_protocol.md)|Disallow using invalid protocol||✔|
 
 ### Best Practices/Naming Conventions
 

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -51,6 +51,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_s3_bucket_invalid_acl|Disallow invalid ACL rule for S3 bucket||✔|
 |aws_s3_bucket_invalid_region|Disallow invalid region for S3 bucket||✔|
 |aws_spot_fleet_request_invalid_excess_capacity_termination_policy|Disallow invalid excess capacity termination policy||✔|
+|[aws_security_group_rule_invalid_protocol](aws_security_group_rule_invalid_protocol.md)|Disallow using invalid protocol||✔|
 
 ### Best Practices/Naming Conventions
 

--- a/docs/rules/aws_security_group_rule_invalid_protocol.md
+++ b/docs/rules/aws_security_group_rule_invalid_protocol.md
@@ -1,0 +1,33 @@
+# aws_security_group_rule_invalid_protocol
+
+Disallow using invalid protocol.
+
+## Example
+
+```hcl
+resource "aws_security_group_rule" "sample" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "https"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "https" is an invalid protocol. (aws_security_group_rule_invalid_protocol)
+
+  on terraform.tf line 5:
+   5:   protocol  = "https"
+```
+
+
+## Why
+
+Apply will fail. (Plan will succeed with the invalid value though)
+
+## How To Fix
+
+Select valid protocol according to the [document](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SecurityGroupRule.html)

--- a/rules/aws_security_group_rule_invalid_protocol.go
+++ b/rules/aws_security_group_rule_invalid_protocol.go
@@ -25,6 +25,7 @@ func NewAwsSecurityGroupRuleInvalidProtocolRule() *AwsSecurityGroupRuleInvalidPr
 		resourceType:  "aws_security_group_rule",
 		attributeName: "protocol",
 		protocols: map[string]struct{}{
+			"all":    {},
 			"tcp":    {},
 			"udp":    {},
 			"icmp":   {},

--- a/rules/aws_security_group_rule_invalid_protocol.go
+++ b/rules/aws_security_group_rule_invalid_protocol.go
@@ -1,0 +1,95 @@
+package rules
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsSecurityGroupRuleInvalidProtocolRule checks whether "protocol" has invalid value
+type AwsSecurityGroupRuleInvalidProtocolRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+	protocols     map[string]struct{}
+}
+
+// NewAwsSecurityGroupRuleInvalidProtocolRule returns new rule with default attributes
+func NewAwsSecurityGroupRuleInvalidProtocolRule() *AwsSecurityGroupRuleInvalidProtocolRule {
+	return &AwsSecurityGroupRuleInvalidProtocolRule{
+		resourceType:  "aws_security_group_rule",
+		attributeName: "protocol",
+		protocols: map[string]struct{}{
+			"tcp":    {},
+			"udp":    {},
+			"icmp":   {},
+			"icmpv6": {},
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsSecurityGroupRuleInvalidProtocolRule) Name() string {
+	return "aws_security_group_rule_invalid_protocol"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsSecurityGroupRuleInvalidProtocolRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsSecurityGroupRuleInvalidProtocolRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsSecurityGroupRuleInvalidProtocolRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether "protocol" has invalid value
+func (r *AwsSecurityGroupRuleInvalidProtocolRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.attributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		var protocol string
+		err := runner.EvaluateExpr(attribute.Expr, &protocol, nil)
+
+		err = runner.EnsureNoError(err, func() error {
+			if _, err := strconv.Atoi(protocol); err == nil {
+				return nil
+			}
+			if _, ok := r.protocols[strings.ToLower(protocol)]; !ok {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf("\"%s\" is an invalid protocol.", protocol),
+					attribute.Expr.Range(),
+				)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/aws_security_group_rule_invalid_protocol_test.go
+++ b/rules/aws_security_group_rule_invalid_protocol_test.go
@@ -1,0 +1,66 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsSecurityGroupRuleInvalidProtocol(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "valid protocol",
+			Content: `
+resource "aws_security_group_rule" "this" {
+    protocol = "tcp"
+}
+`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "valid number as protocol",
+			Content: `
+resource "aws_security_group_rule" "this" {
+    protocol = "-1"
+}
+`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "invalid protocol",
+			Content: `
+resource "aws_security_group_rule" "this" {
+    protocol = "http"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsSecurityGroupRuleInvalidProtocolRule(),
+					Message: "\"http\" is an invalid protocol.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 16},
+						End:      hcl.Pos{Line: 3, Column: 22},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsSecurityGroupRuleInvalidProtocolRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -38,6 +38,7 @@ var manualRules = []tflint.Rule{
 	NewAwsIAMGroupPolicyTooLongRule(),
 	NewAwsAcmCertificateLifecycleRule(),
 	NewAwsElasticBeanstalkEnvironmentInvalidNameFormatRule(),
+	NewAwsSecurityGroupRuleInvalidProtocolRule(),
 }
 
 // Rules is a list of all rules


### PR DESCRIPTION
Add `aws_security_group_rule_invalid_protocol` rule.

This rule checks whether `protocol` has an invalid value as protocol.