### PR TITLE
add http2and3 and http3 as valid values in aws_cloudfront_distribution http_version

### DIFF
--- a/rules/models/aws_cloudfront_distribution_invalid_http_version.go
+++ b/rules/models/aws_cloudfront_distribution_invalid_http_version.go
@@ -27,6 +27,8 @@ func NewAwsCloudfrontDistributionInvalidHTTPVersionRule() *AwsCloudfrontDistribu
 		enum: []string{
 			"http1.1",
 			"http2",
+			"http2and3",
+			"http3",
 		},
 	}
 }


### PR DESCRIPTION
Support http3 and http2and3 as valid values for the http_version argument on cloudfront distributions.
Available since [provider release v4.27.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.27.0)