### PR TITLE
build: Improve Go workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,18 +23,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-    - name: Restore Cache
-      uses: actions/cache@v3
-      with:
-        path: |-
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ matrix.os }}-go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version-file: 'go.mod'
+        cache: true
     - name: Run tests
       run: make test
     - name: Run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
     - name: Install TFLint
       run: curl -sL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
     - name: Install plugin (Linux)

--- a/.github/workflows/generated_code_checks.yml
+++ b/.github/workflows/generated_code_checks.yml
@@ -13,17 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-    - name: Restore Cache
-      uses: actions/cache@v3
-      with:
-        path: |-
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version-file: 'go.mod'
+        cache: true
     - name: go generate and diff checks
       run: go generate ./... && git diff --exit-code

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
     - name: goreleaser check
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -13,7 +13,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
       - run: |
           go get github.com/aws/aws-sdk-go
           go mod tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-    - name: Restore Cache
-      uses: actions/cache@v3
-      with:
-        path: |-
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version-file: 'go.mod'
+        cache: true
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:


### PR DESCRIPTION
This PR switches the Go version declaration in each workflow file to `go-version-file`.
https://github.com/actions/setup-go/pull/62

Additionally, enable the `cache` option to remove the dependency of actions/cache
https://github.com/actions/setup-go/pull/228