### PR TITLE
Adding lint testing for heredocs

### DIFF
--- a/docs/rules/aws_policy_heredocs_disallowed.md
+++ b/docs/rules/aws_policy_heredocs_disallowed.md
@@ -1,0 +1,71 @@
+# aws_policy_heredocs_disallowed
+
+This rule ensures that heredocs are not in use across the terraform configuration
+
+## Example
+
+We prefer a jsonencoded configuration of a policy
+```hcl
+  resource "aws_iam_policy" "test" {
+    policy = jsonencode({
+        Statement = [
+            {
+                Action = [
+                    "iam:PassRole"
+                ],
+            }
+        ]
+    })
+  }
+```
+over one with a heredoc:
+```hcl
+resource "aws_iam_policy" "test" {
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Action":  [
+        "iam:PassRole"
+      ],
+    }
+  ]
+}
+EOF
+}
+```
+
+
+```
+$ tflint
+1 issue(s) found:
+
+Notice: Avoid Use of HEREDOC syntax for policy documents (aws_policy_heredocs_disallowed)
+
+  on test.tf line 3:
+ 3:   policy = <<EOF
+ 4: {
+
+```
+
+
+## Why
+
+Preference is made to policy documents written with jsonencode() functionality vs the Heredoc functionality.
+
+## How To Fix
+
+convert your heredoc code to json
+```hcl
+  resource "aws_iam_policy" "test" {
+    policy = jsonencode({
+        Statement = [
+            {
+                Action = [
+                    "iam:PassRole"
+                ],
+            }
+        ]
+    })
+  }
+```

--- a/rules/aws_policy_heredocs_disallowed.go
+++ b/rules/aws_policy_heredocs_disallowed.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+    "strings"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsPolicyHeredocsDisallowedRule checks that policies are not defined with Heredoc format
+type AwsPolicyHeredocsDisallowedRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsPolicyHeredocsDisallowedRule returns new rule with default attributes
+func NewAwsPolicyHeredocsDisallowedRule() *AwsPolicyHeredocsDisallowedRule {
+	return &AwsPolicyHeredocsDisallowedRule{
+		resourceType:  "aws_iam_policy",
+		attributeName: "policy",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsPolicyHeredocsDisallowedRule) Name() string {
+	return "aws_policy_heredocs_disallowed"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsPolicyHeredocsDisallowedRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *AwsPolicyHeredocsDisallowedRule) Severity() tflint.Severity {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *AwsPolicyHeredocsDisallowedRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks if a heredoc block is in use.
+func (r *AwsPolicyHeredocsDisallowedRule) Check(runner tflint.Runner) error {
+
+	path, err := runner.GetModulePath()
+	if err != nil {
+		return err
+	}
+	if !path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
+	files, err := runner.GetFiles()
+	if err != nil {
+		return err
+	}
+	for name, file := range files {
+		if err := r.checkHeredocs(runner, name, file); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *AwsPolicyHeredocsDisallowedRule) checkHeredocs(runner tflint.Runner, filename string, file *hcl.File) error {
+	if strings.HasSuffix(filename, ".json") {
+		return nil
+	}
+
+	tokens, diags := hclsyntax.LexConfig(file.Bytes, filename, hcl.InitialPos)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	for _, token := range tokens {
+		if token.Type != hclsyntax.TokenOHeredoc && token.Type != hclsyntax.TokenCHeredoc {
+			continue
+		}
+
+		if err := runner.EmitIssue(
+			r,
+			"Avoid Use of HEREDOC syntax for policy documents",
+			token.Range,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/aws_policy_heredocs_disallowed_test.go
+++ b/rules/aws_policy_heredocs_disallowed_test.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsPolicyHeredocsDisallowed(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "No Heredoc",
+			Content: `
+resource "aws_iam_policy" "test" {
+	policy = jsonencode({
+		Statement = [
+			{
+				Action = [
+					"iam:PassRole"
+				],
+			}
+		]
+	})
+}
+`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name:    "EOF for a policy",
+			Content: `
+resource "aws_iam_policy" "test" {
+	policy = <<EOF
+{
+	"Statement": [
+		{
+			"Action":  [
+				"iam:PassRole"
+			],
+		}
+	]
+}
+EOF
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsPolicyHeredocsDisallowedRule(),
+					Message: "Avoid Use of HEREDOC syntax for policy documents",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 11},
+						End:      hcl.Pos{Line: 4, Column: 1},
+					},
+				},
+				{
+					Rule:    NewAwsPolicyHeredocsDisallowedRule(),
+					Message: "Avoid Use of HEREDOC syntax for policy documents",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 13, Column: 1},
+						End:      hcl.Pos{Line: 13, Column: 4},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsPolicyHeredocsDisallowedRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -40,6 +40,7 @@ var manualRules = []tflint.Rule{
 	NewAwsElasticBeanstalkEnvironmentInvalidNameFormatRule(),
 	NewAwsSecurityGroupInvalidProtocolRule(),
 	NewAwsSecurityGroupRuleInvalidProtocolRule(),
+	NewAwsPolicyHeredocsDisallowedRule(),
 }
 
 // Rules is a list of all rules


### PR DESCRIPTION
Adding heredoc scanning, allowing someone to enable the rule and get notices when heredoc syntax is used

It is not limited to only aws resources, if someone is able to contribute recommendations on how to filter on resource block names, while still parsing lexical tokens, I'd welcome it! 

Partially resolves: https://github.com/terraform-linters/tflint-ruleset-aws/issues/36