### PR TITLE
Add aws_iam_policy_attachment_has_alternatives rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,6 +68,7 @@ These rules enforce best practices and naming conventions:
 |[aws_elasticache_replication_group_previous_type](aws_elasticache_replication_group_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_replication_group_default_parameter_group](aws_elasticache_replication_group_default_parameter_group.md)|Disallow using default parameter group|✔|
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|
+|[aws_iam_policy_attachment_has_alternatives](aws_iam_policy_attachment_has_alternatives.md)|Consider alternative resources to `aws_iam_policy_attachment`||
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -68,6 +68,7 @@ These rules enforce best practices and naming conventions:
 |[aws_elasticache_replication_group_previous_type](aws_elasticache_replication_group_previous_type.md)|Disallow using previous node types|✔|
 |[aws_elasticache_replication_group_default_parameter_group](aws_elasticache_replication_group_default_parameter_group.md)|Disallow using default parameter group|✔|
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|
+|[aws_iam_policy_attachment_has_alternatives](aws_iam_policy_attachment_has_alternatives.md)|Consider alternative resources to `aws_iam_policy_attachment`||
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||

--- a/docs/rules/aws_iam_policy_attachment_has_alternatives.md
+++ b/docs/rules/aws_iam_policy_attachment_has_alternatives.md
@@ -1,0 +1,36 @@
+# aws_iam_policy_attachment_has_alternatives
+
+Consider alternative resources to `aws_iam_policy_attachment`.
+
+## Configuration
+
+```hcl
+rule "aws_iam_policy_attachment_has_alternatives" {
+  enabled = true
+}
+```
+
+## Example
+
+```hcl
+resource "aws_iam_policy_attachment" "attachment" {
+	name = "test_attachment"
+}
+```
+
+```shell
+$ tflint
+1 issue(s) found:
+Warning: Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead. (aws_iam_policy_attachment_has_alternatives)
+  on template.tf line 2:
+   2:   name "test_attachment" // Consider alternatives!
+
+```
+
+## Why
+
+The `aws_iam_policy_attachment` resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single `aws_iam_policy_attachment` resource. This means that even any users/roles/groups that have the attached policy via any other mechanism (including other Terraform resources) will have that attached policy revoked by this resource. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment
+
+## How To Fix
+
+Consider `aws_iam_role_policy_attachment`, `aws_iam_user_policy_attachment`, or `aws_iam_group_policy_attachment` instead. These resources do not enforce exclusive attachment of an IAM policy.

--- a/rules/aws_iam_policy_attachment_has_alternatives.go
+++ b/rules/aws_iam_policy_attachment_has_alternatives.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsIAMPolicyAttachmentHasAlternativesRule warns that the resource has alternatives recommended
+type AwsIAMPolicyAttachmentHasAlternativesRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// AwsIAMPolicyAttachmentHasAlternativesRule returns new rule with default attributes
+func NewAwsIAMPolicyAttachmentHasAlternativesRule() *AwsIAMPolicyAttachmentHasAlternativesRule {
+	return &AwsIAMPolicyAttachmentHasAlternativesRule{
+		resourceType:  "aws_iam_policy_attachment",
+		attributeName: "name",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsIAMPolicyAttachmentHasAlternativesRule) Name() string {
+	return "aws_iam_policy_attachment_has_alternatives"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsIAMPolicyAttachmentHasAlternativesRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *AwsIAMPolicyAttachmentHasAlternativesRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsIAMPolicyAttachmentHasAlternativesRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks the length of the policy
+func (r *AwsIAMPolicyAttachmentHasAlternativesRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{{Name: r.attributeName}},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		var name string
+		err := runner.EvaluateExpr(attribute.Expr, &name, nil)
+		runner.EmitIssue(
+			r,
+			"Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead.",
+			attribute.Expr.Range(),
+		)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/aws_iam_policy_attachment_has_alternatives_test.go
+++ b/rules/aws_iam_policy_attachment_has_alternatives_test.go
@@ -1,0 +1,51 @@
+package rules
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsIAMPolicyAttachmentHasAlternativesRule(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "resource has alternatives",
+			Content: `
+resource "aws_iam_policy_attachment" "attachment" {
+	name = "test_attachment"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsIAMPolicyAttachmentHasAlternativesRule(),
+					Message: "Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 9},
+						End:      hcl.Pos{Line: 3, Column: 26},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsIAMPolicyAttachmentHasAlternativesRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -31,6 +31,7 @@ var manualRules = []tflint.Rule{
 	NewAwsElastiCacheReplicationGroupDefaultParameterGroupRule(),
 	NewAwsElastiCacheReplicationGroupInvalidTypeRule(),
 	NewAwsElastiCacheReplicationGroupPreviousTypeRule(),
+	NewAwsIAMPolicyAttachmentHasAlternativesRule(),
 	NewAwsIAMPolicySidInvalidCharactersRule(),
 	NewAwsIAMPolicyTooLongPolicyRule(),
 	NewAwsLambdaFunctionDeprecatedRuntimeRule(),


### PR DESCRIPTION
Add `aws_iam_policy_attachment_has_alternatives` rule.

This rule warns when there are recommended alternatives to the resource, and is _disabled_ by default

This recommendation is documented by HashiCorp in the AWS Provider documentation due to  common misuse: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment

In this particular case the blast radius of misuse can be severe across an entire organisation account and cause production outages due to the unexpected removal of permissions.

After reviewing past issues (#35) and PR's ([tflint:#769](https://github.com/terraform-linters/tflint/pull/769)) I think that adding individual rules informed by HashiCorp recommendations is the most practical approach for community maintenance and this PR could be used as an approachable template for further rules without deep knowledge of the project (I used #355)

Thankyou for your consideration.