### PR TITLE
Add signatures for keyless signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     tags:
     - v*.*.*
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -20,6 +24,8 @@ jobs:
       with:
         go-version-file: 'go.mod'
         cache: true
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v2
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,19 @@ changelog:
   skip: true
 checksum:
   name_template: 'checksums.txt'
+signs:
+  - cmd: cosign
+    env:
+    - COSIGN_EXPERIMENTAL=1
+    signature: '${artifact}.keyless.sig'
+    certificate: '${artifact}.pem'
+    output: true
+    artifacts: checksum
+    args:
+      - sign-blob
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
 release:
   github:
     owner: terraform-linters


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1361

This signature is not yet used by `tflint --init`, but it will be used in future releases.