### PR TITLE
Prefer credentials in "plugin" blocks over "provider" blocks

### DIFF
--- a/aws/runner.go
+++ b/aws/runner.go
@@ -30,7 +30,7 @@ func NewRunner(runner tflint.Runner, config *Config) (*Runner, error) {
 			credentials["aws"] = Credentials{}
 		}
 		for k, cred := range credentials {
-			client, err := NewClient(config.toCredentials().Merge(cred))
+			client, err := NewClient(cred.Merge(config.toCredentials()))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/385

Our documentation says that credentials declared in `.tflint.hcl` take precedence over one in provider blocks in `.tf` file, but the actual behavior was the opposite.

This PR fixes this as a bug because the priority is correct in the documentation.