### PR TITLE
Add assume role configuration in Config struct

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -16,14 +16,14 @@ type Config struct {
 
 func (c *Config) toCredentials() Credentials {
 	return Credentials{
-		AccessKey: 				c.AccessKey,
-		SecretKey: 				c.SecretKey,
-		Region:    				c.Region,
-		Profile:   				c.Profile,
-		CredsFile: 				c.SharedCredentialsFile,
-		AssumeRoleARN: 			c.AssumeRoleARN,
-		AssumeRoleExternalID: 	c.AssumeRoleExternalID,
-		AssumeRolePolicy: 		c.AssumeRolePolicy,
-		AssumeRoleSessionName: 	c.AssumeRoleSessionName,
+		AccessKey:              c.AccessKey,
+		SecretKey:              c.SecretKey,
+		Region:                 c.Region,
+		Profile:                c.Profile,
+		CredsFile:              c.SharedCredentialsFile,
+		AssumeRoleARN:          c.AssumeRoleARN,
+		AssumeRoleExternalID:   c.AssumeRoleExternalID,
+		AssumeRolePolicy:       c.AssumeRolePolicy,
+		AssumeRoleSessionName:  c.AssumeRoleSessionName,
 	}
 }

--- a/aws/config.go
+++ b/aws/config.go
@@ -8,14 +8,22 @@ type Config struct {
 	Region                string `hclext:"region,optional"`
 	Profile               string `hclext:"profile,optional"`
 	SharedCredentialsFile string `hclext:"shared_credentials_file,optional"`
+	AssumeRoleARN         string `hclext:"assume_role_arn,optional"`
+	AssumeRoleExternalID  string `hclext:"assume_role_external_id,optional"`
+	AssumeRolePolicy      string `hclext:"assume_role_policy,optional"`
+	AssumeRoleSessionName string `hclext:"assume_role_session_name,optional"`
 }
 
 func (c *Config) toCredentials() Credentials {
 	return Credentials{
-		AccessKey: c.AccessKey,
-		SecretKey: c.SecretKey,
-		Region:    c.Region,
-		Profile:   c.Profile,
-		CredsFile: c.SharedCredentialsFile,
+		AccessKey: 				c.AccessKey,
+		SecretKey: 				c.SecretKey,
+		Region:    				c.Region,
+		Profile:   				c.Profile,
+		CredsFile: 				c.SharedCredentialsFile,
+		AssumeRoleARN: 			c.AssumeRoleARN,
+		AssumeRoleExternalID: 	c.AssumeRoleExternalID,
+		AssumeRolePolicy: 		c.AssumeRolePolicy,
+		AssumeRoleSessionName: 	c.AssumeRoleSessionName,
 	}
 }

--- a/aws/config.go
+++ b/aws/config.go
@@ -1,29 +1,38 @@
 package aws
 
+type AssumeRole struct {
+	RoleARN     string `hclext:"role_arn,optional"`
+	ExternalID  string `hclext:"external_id,optional"`
+	Policy      string `hclext:"policy,optional"`
+	SessionName string `hclext:"session_name,optional"`
+}
+
 // Config is the configuration for the ruleset.
 type Config struct {
-	DeepCheck             bool   `hclext:"deep_check,optional"`
-	AccessKey             string `hclext:"access_key,optional"`
-	SecretKey             string `hclext:"secret_key,optional"`
-	Region                string `hclext:"region,optional"`
-	Profile               string `hclext:"profile,optional"`
-	SharedCredentialsFile string `hclext:"shared_credentials_file,optional"`
-	AssumeRoleARN         string `hclext:"assume_role_arn,optional"`
-	AssumeRoleExternalID  string `hclext:"assume_role_external_id,optional"`
-	AssumeRolePolicy      string `hclext:"assume_role_policy,optional"`
-	AssumeRoleSessionName string `hclext:"assume_role_session_name,optional"`
+	DeepCheck              bool       `hclext:"deep_check,optional"`
+	AccessKey              string     `hclext:"access_key,optional"`
+	SecretKey              string     `hclext:"secret_key,optional"`
+	Region                 string     `hclext:"region,optional"`
+	Profile                string     `hclext:"profile,optional"`
+	SharedCredentialsFile  string     `hclext:"shared_credentials_file,optional"`
+	AssumeRole            *AssumeRole `hclext:"assume_role,block"`
 }
 
 func (c *Config) toCredentials() Credentials {
-	return Credentials{
-		AccessKey:             c.AccessKey,
-		SecretKey:             c.SecretKey,
-		Region:                c.Region,
-		Profile:               c.Profile,
-		CredsFile:             c.SharedCredentialsFile,
-		AssumeRoleARN:         c.AssumeRoleARN,
-		AssumeRoleExternalID:  c.AssumeRoleExternalID,
-		AssumeRolePolicy:      c.AssumeRolePolicy,
-		AssumeRoleSessionName: c.AssumeRoleSessionName,
+	credentials := Credentials{
+		AccessKey: c.AccessKey,
+		SecretKey: c.SecretKey,
+		Region:    c.Region,
+		Profile:   c.Profile,
+		CredsFile: c.SharedCredentialsFile,
 	}
+
+	if c.AssumeRole != nil {
+		credentials.AssumeRoleARN         = c.AssumeRole.RoleARN
+		credentials.AssumeRoleExternalID  = c.AssumeRole.ExternalID
+		credentials.AssumeRolePolicy      = c.AssumeRole.Policy
+		credentials.AssumeRoleSessionName = c.AssumeRole.SessionName
+	}
+
+	return credentials
 }

--- a/aws/config.go
+++ b/aws/config.go
@@ -16,14 +16,14 @@ type Config struct {
 
 func (c *Config) toCredentials() Credentials {
 	return Credentials{
-		AccessKey:              c.AccessKey,
-		SecretKey:              c.SecretKey,
-		Region:                 c.Region,
-		Profile:                c.Profile,
-		CredsFile:              c.SharedCredentialsFile,
-		AssumeRoleARN:          c.AssumeRoleARN,
-		AssumeRoleExternalID:   c.AssumeRoleExternalID,
-		AssumeRolePolicy:       c.AssumeRolePolicy,
-		AssumeRoleSessionName:  c.AssumeRoleSessionName,
+		AccessKey:             c.AccessKey,
+		SecretKey:             c.SecretKey,
+		Region:                c.Region,
+		Profile:               c.Profile,
+		CredsFile:             c.SharedCredentialsFile,
+		AssumeRoleARN:         c.AssumeRoleARN,
+		AssumeRoleExternalID:  c.AssumeRoleExternalID,
+		AssumeRolePolicy:      c.AssumeRolePolicy,
+		AssumeRoleSessionName: c.AssumeRoleSessionName,
 	}
 }


### PR DESCRIPTION
My Terraform project has the following folder structure:
```
<root>
├ environments
│　├ dev
│　├ stg
│　├ prod
│　└ <and more...>
├ modules
│　└ <some modules>
├ <some shellscript>
└ .tflint.hcl 
```

And I'm running tflint with the following shell script.
```sh
#!/bin/bash
PATH_DIR_SCRIPT="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)";

set -euxo pipefail
find . -type f -name "*.tf" -not -path "*/.terraform/*" -exec dirname {} \; \
    | sort -u \
    | while read line; do
        cd $line;
        echo "processing $PWD ..."
        terraform init -backend=false && tflint --config $PATH_DIR_SCRIPT/.tflint.hcl;
        cd -;
      done
```

The problem is that when inspecting the modules in the `modules` folder, the AssumeRole is not possible because there is no provider clause.
Modules in the environments folder work fine because they have a provider clause specified.

Therefore, it would be convenient if AssumeRole can be set in `.tflint.hcl`.
This allows TFLint to run with a consistent Role regardless of whether it is set in the module.

Please consider adding this function.
Thank you.