### PR TITLE
`elasticache_cluster_previous_type`: fix panic on empty string

### DIFF
--- a/rules/aws_elasticache_cluster_invalid_type_test.go
+++ b/rules/aws_elasticache_cluster_invalid_type_test.go
@@ -32,6 +32,24 @@ resource "aws_elasticache_cluster" "redis" {
 			},
 		},
 		{
+			Name: "empty is invalid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = ""
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsElastiCacheClusterInvalidTypeRule(),
+					Message: "\"\" is invalid node type.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 17},
+						End:      hcl.Pos{Line: 3, Column: 19},
+					},
+				},
+			},
+		},
+		{
 			Name: "cache.t2.micro is valid",
 			Content: `
 resource "aws_elasticache_cluster" "redis" {

--- a/rules/aws_elasticache_cluster_previous_type.go
+++ b/rules/aws_elasticache_cluster_previous_type.go
@@ -64,7 +64,12 @@ func (r *AwsElastiCacheClusterPreviousTypeRule) Check(runner tflint.Runner) erro
 		err := runner.EvaluateExpr(attribute.Expr, &nodeType, nil)
 
 		err = runner.EnsureNoError(err, func() error {
-			if previousElastiCacheNodeTypes[strings.Split(nodeType, ".")[1]] {
+			parts := strings.Split(nodeType, ".")
+			if len(parts) != 3 {
+				return nil
+			}
+
+			if previousElastiCacheNodeTypes[parts[1]] {
 				runner.EmitIssue(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),

--- a/rules/aws_elasticache_cluster_previous_type_test.go
+++ b/rules/aws_elasticache_cluster_previous_type_test.go
@@ -39,6 +39,14 @@ resource "aws_elasticache_cluster" "redis" {
 }`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "empty type",
+			Content: `
+				resource "aws_elasticache_cluster" "redis" {
+					node_type = ""
+				}`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewAwsElastiCacheClusterPreviousTypeRule()


### PR DESCRIPTION
Fixes a panic that resulted from an out-of-bound read. Previouisly, the rule naively assumed that `node_type` is always `"cache.*"`. Now, if the node type does not have all 3 parts, the rule returns early.

This was a regression introduced in https://github.com/terraform-linters/tflint-ruleset-aws/pull/309.