### PR TITLE
Fix submodule checkout issue

### DIFF
--- a/.github/workflows/generated_code_checks.yml
+++ b/.github/workflows/generated_code_checks.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        submodules: true
+    - name: Checkout submodules
+    - run: git submodule update --init --depth=0
     - name: Set up Go
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -9,8 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
+      - run: git submodule update --init --depth=0
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'


### PR DESCRIPTION
A few days ago, aws-sdk-go submodule checkout failed with the following error:

```
  /usr/bin/git submodule sync
  /usr/bin/git -c protocol.version=2 submodule update --init --force --depth=1
  Submodule 'rules/models/aws-sdk-go' (https://github.com/aws/aws-sdk-go) registered for path 'rules/models/aws-sdk-go'
  Cloning into '/home/runner/work/tflint-ruleset-aws/tflint-ruleset-aws/rules/models/aws-sdk-go'...
  remote: app=lariat msg="[FATAL]: Internal error"        
  remote: aborting due to possible repository corruption on the remote side.
  Error: fatal: early EOF
  Error: fatal: fetch-pack: invalid index-pack output
  Error: fatal: clone of 'https://github.com/aws/aws-sdk-go' into submodule path '/home/runner/work/tflint-ruleset-aws/tflint-ruleset-aws/rules/models/aws-sdk-go' failed
```

https://github.com/terraform-linters/tflint-ruleset-aws/actions/runs/4214996572/jobs/7316120928

From what I've researched, it seems likely that this is an issue due to repository size. This pull request sets `--depth=0` to reduce the repository size to fetch.