### PR TITLE
models: allow tests to specify multiple cases

### DIFF
--- a/rules/models/aws_acmpca_certificate_authority_invalid_type_test.go
+++ b/rules/models/aws_acmpca_certificate_authority_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAcmpcaCertificateAuthorityInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_acmpca_certificate_authority" "foo" {
-	type = "ORDINATE"
-}`,
+	type = SUBORDINATE
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_acmpca_certificate_authority" "foo" {
+	type = ORDINATE
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAcmpcaCertificateAuthorityInvalidTypeRule(),
-					Message: `"ORDINATE" is an invalid value as type`,
+					Message: `ORDINATE is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_acmpca_certificate_authority" "foo" {
-	type = "SUBORDINATE"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ami_invalid_architecture_test.go
+++ b/rules/models/aws_ami_invalid_architecture_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAMIInvalidArchitectureRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ami" "foo" {
-	architecture = "x86"
-}`,
+	architecture = x86_64
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ami" "foo" {
+	architecture = x86
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAMIInvalidArchitectureRule(),
-					Message: `"x86" is an invalid value as architecture`,
+					Message: `x86 is an invalid value as architecture`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ami" "foo" {
-	architecture = "x86_64"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_authorizer_invalid_type_test.go
+++ b/rules/models/aws_api_gateway_authorizer_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayAuthorizerInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_authorizer" "foo" {
-	type = "RESPONSE"
-}`,
+	type = TOKEN
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_authorizer" "foo" {
+	type = RESPONSE
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayAuthorizerInvalidTypeRule(),
-					Message: `"RESPONSE" is an invalid value as type`,
+					Message: `RESPONSE is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_authorizer" "foo" {
-	type = "TOKEN"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_gateway_response_invalid_response_type_test.go
+++ b/rules/models/aws_api_gateway_gateway_response_invalid_response_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayGatewayResponseInvalidResponseTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_gateway_response" "foo" {
-	response_type = "4XX"
-}`,
+	response_type = UNAUTHORIZED
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_gateway_response" "foo" {
+	response_type = 4XX
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayGatewayResponseInvalidResponseTypeRule(),
-					Message: `"4XX" is an invalid value as response_type`,
+					Message: `4XX is an invalid value as response_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_gateway_response" "foo" {
-	response_type = "UNAUTHORIZED"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_gateway_response_invalid_status_code_test.go
+++ b/rules/models/aws_api_gateway_gateway_response_invalid_status_code_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayGatewayResponseInvalidStatusCodeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_gateway_response" "foo" {
-	status_code = "004"
-}`,
+	status_code = 200
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_gateway_response" "foo" {
+	status_code = 004
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayGatewayResponseInvalidStatusCodeRule(),
-					Message: `"004" does not match valid pattern ^[1-5]\d\d$`,
+					Message: `004 does not match valid pattern ^[1-5]\d\d$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_gateway_response" "foo" {
-	status_code = "200"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_integration_invalid_connection_type_test.go
+++ b/rules/models/aws_api_gateway_integration_invalid_connection_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayIntegrationInvalidConnectionTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_integration" "foo" {
-	connection_type = "INTRANET"
-}`,
+	connection_type = INTERNET
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_integration" "foo" {
+	connection_type = INTRANET
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayIntegrationInvalidConnectionTypeRule(),
-					Message: `"INTRANET" is an invalid value as connection_type`,
+					Message: `INTRANET is an invalid value as connection_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_integration" "foo" {
-	connection_type = "INTERNET"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_integration_invalid_content_handling_test.go
+++ b/rules/models/aws_api_gateway_integration_invalid_content_handling_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayIntegrationInvalidContentHandlingRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_integration" "foo" {
-	content_handling = "CONVERT_TO_FILE"
-}`,
+	content_handling = CONVERT_TO_BINARY
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_integration" "foo" {
+	content_handling = CONVERT_TO_FILE
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayIntegrationInvalidContentHandlingRule(),
-					Message: `"CONVERT_TO_FILE" is an invalid value as content_handling`,
+					Message: `CONVERT_TO_FILE is an invalid value as content_handling`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_integration" "foo" {
-	content_handling = "CONVERT_TO_BINARY"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_integration_invalid_type_test.go
+++ b/rules/models/aws_api_gateway_integration_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayIntegrationInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_integration" "foo" {
-	type = "AWS_HTTP"
-}`,
+	type = HTTP
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_integration" "foo" {
+	type = AWS_HTTP
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayIntegrationInvalidTypeRule(),
-					Message: `"AWS_HTTP" is an invalid value as type`,
+					Message: `AWS_HTTP is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_integration" "foo" {
-	type = "HTTP"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_rest_api_invalid_api_key_source_test.go
+++ b/rules/models/aws_api_gateway_rest_api_invalid_api_key_source_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayRestAPIInvalidAPIKeySourceRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_rest_api" "foo" {
-	api_key_source = "BODY"
-}`,
+	api_key_source = AUTHORIZER
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_rest_api" "foo" {
+	api_key_source = BODY
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayRestAPIInvalidAPIKeySourceRule(),
-					Message: `"BODY" is an invalid value as api_key_source`,
+					Message: `BODY is an invalid value as api_key_source`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_rest_api" "foo" {
-	api_key_source = "AUTHORIZER"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_api_gateway_stage_invalid_cache_cluster_size_test.go
+++ b/rules/models/aws_api_gateway_stage_invalid_cache_cluster_size_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAPIGatewayStageInvalidCacheClusterSizeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_api_gateway_stage" "foo" {
-	cache_cluster_size = "6.2"
-}`,
+	cache_cluster_size = 6.1
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_api_gateway_stage" "foo" {
+	cache_cluster_size = 6.2
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAPIGatewayStageInvalidCacheClusterSizeRule(),
-					Message: `"6.2" is an invalid value as cache_cluster_size`,
+					Message: `6.2 is an invalid value as cache_cluster_size`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_api_gateway_stage" "foo" {
-	cache_cluster_size = "6.1"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_appautoscaling_policy_invalid_policy_type_test.go
+++ b/rules/models/aws_appautoscaling_policy_invalid_policy_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAppautoscalingPolicyInvalidPolicyTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_appautoscaling_policy" "foo" {
-	policy_type = "StopScaling"
-}`,
+	policy_type = StepScaling
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_appautoscaling_policy" "foo" {
+	policy_type = StopScaling
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAppautoscalingPolicyInvalidPolicyTypeRule(),
-					Message: `"StopScaling" is an invalid value as policy_type`,
+					Message: `StopScaling is an invalid value as policy_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_appautoscaling_policy" "foo" {
-	policy_type = "StepScaling"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_appautoscaling_policy_invalid_scalable_dimension_test.go
+++ b/rules/models/aws_appautoscaling_policy_invalid_scalable_dimension_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAppautoscalingPolicyInvalidScalableDimensionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_appautoscaling_policy" "foo" {
-	scalable_dimension = "ecs:service:DesireCount"
-}`,
+	scalable_dimension = ecs:service:DesiredCount
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_appautoscaling_policy" "foo" {
+	scalable_dimension = ecs:service:DesireCount
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAppautoscalingPolicyInvalidScalableDimensionRule(),
-					Message: `"ecs:service:DesireCount" is an invalid value as scalable_dimension`,
+					Message: `ecs:service:DesireCount is an invalid value as scalable_dimension`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_appautoscaling_policy" "foo" {
-	scalable_dimension = "ecs:service:DesiredCount"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_appautoscaling_policy_invalid_service_namespace_test.go
+++ b/rules/models/aws_appautoscaling_policy_invalid_service_namespace_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAppautoscalingPolicyInvalidServiceNamespaceRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_appautoscaling_policy" "foo" {
-	service_namespace = "eks"
-}`,
+	service_namespace = ecs
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_appautoscaling_policy" "foo" {
+	service_namespace = eks
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAppautoscalingPolicyInvalidServiceNamespaceRule(),
-					Message: `"eks" is an invalid value as service_namespace`,
+					Message: `eks is an invalid value as service_namespace`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_appautoscaling_policy" "foo" {
-	service_namespace = "ecs"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_appsync_datasource_invalid_name_test.go
+++ b/rules/models/aws_appsync_datasource_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAppsyncDatasourceInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_appsync_datasource" "foo" {
-	name = "01_tf_example"
-}`,
+	name = tf_appsync_example
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_appsync_datasource" "foo" {
+	name = 01_tf_example
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAppsyncDatasourceInvalidNameRule(),
-					Message: `"01_tf_example" does not match valid pattern ^[_A-Za-z][_0-9A-Za-z]*$`,
+					Message: `01_tf_example does not match valid pattern ^[_A-Za-z][_0-9A-Za-z]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_appsync_datasource" "foo" {
-	name = "tf_appsync_example"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_appsync_datasource_invalid_type_test.go
+++ b/rules/models/aws_appsync_datasource_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAppsyncDatasourceInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_appsync_datasource" "foo" {
-	type = "AMAZON_SIMPLEDB"
-}`,
+	type = AWS_LAMBDA
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_appsync_datasource" "foo" {
+	type = AMAZON_SIMPLEDB
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAppsyncDatasourceInvalidTypeRule(),
-					Message: `"AMAZON_SIMPLEDB" is an invalid value as type`,
+					Message: `AMAZON_SIMPLEDB is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_appsync_datasource" "foo" {
-	type = "AWS_LAMBDA"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_appsync_graphql_api_invalid_authentication_type_test.go
+++ b/rules/models/aws_appsync_graphql_api_invalid_authentication_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsAppsyncGraphqlAPIInvalidAuthenticationTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_appsync_graphql_api" "foo" {
-	authentication_type = "AWS_KEY"
-}`,
+	authentication_type = API_KEY
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_appsync_graphql_api" "foo" {
+	authentication_type = AWS_KEY
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsAppsyncGraphqlAPIInvalidAuthenticationTypeRule(),
-					Message: `"AWS_KEY" is an invalid value as authentication_type`,
+					Message: `AWS_KEY is an invalid value as authentication_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_appsync_graphql_api" "foo" {
-	authentication_type = "API_KEY"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_backup_selection_invalid_name_test.go
+++ b/rules/models/aws_backup_selection_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBackupSelectionInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_backup_selection" "foo" {
-	name = "tf_example_backup_selection_tf_example_backup_selection"
-}`,
+	name = tf_example_backup_selection
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_backup_selection" "foo" {
+	name = tf_example_backup_selection_tf_example_backup_selection
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBackupSelectionInvalidNameRule(),
-					Message: `"tf_example_backup_selection_tf_example_backup_selection" does not match valid pattern ^[a-zA-Z0-9\-\_\.]{1,50}$`,
+					Message: `tf_example_backup_selection_tf_example_backup_selection does not match valid pattern ^[a-zA-Z0-9\-\_\.]{1,50}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_backup_selection" "foo" {
-	name = "tf_example_backup_selection"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_backup_vault_invalid_name_test.go
+++ b/rules/models/aws_backup_vault_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBackupVaultInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_backup_vault" "foo" {
-	name = "example_backup_vault_example_backup_vault_example_backup_vault"
-}`,
+	name = example_backup_vault
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_backup_vault" "foo" {
+	name = example_backup_vault_example_backup_vault_example_backup_vault
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBackupVaultInvalidNameRule(),
-					Message: `"example_backup_vault_example_backup_vault_example_backup_vault" does not match valid pattern ^[a-zA-Z0-9\-\_]{2,50}$`,
+					Message: `example_backup_vault_example_backup_vault_example_backup_vault does not match valid pattern ^[a-zA-Z0-9\-\_]{2,50}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_backup_vault" "foo" {
-	name = "example_backup_vault"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_batch_compute_environment_invalid_state_test.go
+++ b/rules/models/aws_batch_compute_environment_invalid_state_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBatchComputeEnvironmentInvalidStateRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_batch_compute_environment" "foo" {
-	state = "ON"
-}`,
+	state = ENABLED
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_batch_compute_environment" "foo" {
+	state = ON
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBatchComputeEnvironmentInvalidStateRule(),
-					Message: `"ON" is an invalid value as state`,
+					Message: `ON is an invalid value as state`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_batch_compute_environment" "foo" {
-	state = "ENABLED"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_batch_compute_environment_invalid_type_test.go
+++ b/rules/models/aws_batch_compute_environment_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBatchComputeEnvironmentInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_batch_compute_environment" "foo" {
-	type = "CONTROLLED"
-}`,
+	type = MANAGED
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_batch_compute_environment" "foo" {
+	type = CONTROLLED
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBatchComputeEnvironmentInvalidTypeRule(),
-					Message: `"CONTROLLED" is an invalid value as type`,
+					Message: `CONTROLLED is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_batch_compute_environment" "foo" {
-	type = "MANAGED"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_batch_job_definition_invalid_type_test.go
+++ b/rules/models/aws_batch_job_definition_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBatchJobDefinitionInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_batch_job_definition" "foo" {
-	type = "docker"
-}`,
+	type = container
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_batch_job_definition" "foo" {
+	type = docker
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBatchJobDefinitionInvalidTypeRule(),
-					Message: `"docker" is an invalid value as type`,
+					Message: `docker is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_batch_job_definition" "foo" {
-	type = "container"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_batch_job_queue_invalid_state_test.go
+++ b/rules/models/aws_batch_job_queue_invalid_state_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBatchJobQueueInvalidStateRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_batch_job_queue" "foo" {
-	state = "ON"
-}`,
+	state = ENABLED
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_batch_job_queue" "foo" {
+	state = ON
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBatchJobQueueInvalidStateRule(),
-					Message: `"ON" is an invalid value as state`,
+					Message: `ON is an invalid value as state`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_batch_job_queue" "foo" {
-	state = "ENABLED"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_budgets_budget_invalid_account_id_test.go
+++ b/rules/models/aws_budgets_budget_invalid_account_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBudgetsBudgetInvalidAccountIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_budgets_budget" "foo" {
-	account_id = "abcdefghijkl"
-}`,
+	account_id = 123456789012
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_budgets_budget" "foo" {
+	account_id = abcdefghijkl
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBudgetsBudgetInvalidAccountIDRule(),
-					Message: `"abcdefghijkl" does not match valid pattern ^\d{12}$`,
+					Message: `abcdefghijkl does not match valid pattern ^\d{12}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_budgets_budget" "foo" {
-	account_id = "123456789012"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_budgets_budget_invalid_budget_type_test.go
+++ b/rules/models/aws_budgets_budget_invalid_budget_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBudgetsBudgetInvalidBudgetTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_budgets_budget" "foo" {
-	budget_type = "MONEY"
-}`,
+	budget_type = USAGE
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_budgets_budget" "foo" {
+	budget_type = MONEY
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBudgetsBudgetInvalidBudgetTypeRule(),
-					Message: `"MONEY" is an invalid value as budget_type`,
+					Message: `MONEY is an invalid value as budget_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_budgets_budget" "foo" {
-	budget_type = "USAGE"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_budgets_budget_invalid_name_test.go
+++ b/rules/models/aws_budgets_budget_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBudgetsBudgetInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_budgets_budget" "foo" {
-	name = "budget:ec2:monthly"
-}`,
+	name = budget-ec2-monthly
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_budgets_budget" "foo" {
+	name = budget:ec2:monthly
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBudgetsBudgetInvalidNameRule(),
-					Message: `"budget:ec2:monthly" does not match valid pattern ^[^:\\]+$`,
+					Message: `budget:ec2:monthly does not match valid pattern ^[^:\\]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_budgets_budget" "foo" {
-	name = "budget-ec2-monthly"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_budgets_budget_invalid_time_unit_test.go
+++ b/rules/models/aws_budgets_budget_invalid_time_unit_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsBudgetsBudgetInvalidTimeUnitRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_budgets_budget" "foo" {
-	time_unit = "HOURLY"
-}`,
+	time_unit = MONTHLY
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_budgets_budget" "foo" {
+	time_unit = HOURLY
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsBudgetsBudgetInvalidTimeUnitRule(),
-					Message: `"HOURLY" is an invalid value as time_unit`,
+					Message: `HOURLY is an invalid value as time_unit`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_budgets_budget" "foo" {
-	time_unit = "MONTHLY"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloud9_environment_ec2_invalid_instance_type_test.go
+++ b/rules/models/aws_cloud9_environment_ec2_invalid_instance_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloud9EnvironmentEc2InvalidInstanceTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloud9_environment_ec2" "foo" {
-	instance_type = "t20.micro"
-}`,
+	instance_type = t2.micro
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloud9_environment_ec2" "foo" {
+	instance_type = t20.micro
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloud9EnvironmentEc2InvalidInstanceTypeRule(),
-					Message: `"t20.micro" does not match valid pattern ^[a-z][1-9][.][a-z0-9]+$`,
+					Message: `t20.micro does not match valid pattern ^[a-z][1-9][.][a-z0-9]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloud9_environment_ec2" "foo" {
-	instance_type = "t2.micro"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloud9_environment_ec2_invalid_owner_arn_test.go
+++ b/rules/models/aws_cloud9_environment_ec2_invalid_owner_arn_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloud9EnvironmentEc2InvalidOwnerArnRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloud9_environment_ec2" "foo" {
-	owner_arn = "arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment"
-}`,
+	owner_arn = arn:aws:iam::123456789012:user/David
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloud9_environment_ec2" "foo" {
+	owner_arn = arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloud9EnvironmentEc2InvalidOwnerArnRule(),
-					Message: `"arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment" does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):(iam|sts)::\d+:(root|(user\/[\w+=/:,.@-]{1,64}|federated-user\/[\w+=/:,.@-]{2,32}|assumed-role\/[\w+=:,.@-]{1,64}\/[\w+=,.@-]{1,64}))$`,
+					Message: `arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):(iam|sts)::\d+:(root|(user\/[\w+=/:,.@-]{1,64}|federated-user\/[\w+=/:,.@-]{2,32}|assumed-role\/[\w+=:,.@-]{1,64}\/[\w+=,.@-]{1,64}))$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloud9_environment_ec2" "foo" {
-	owner_arn = "arn:aws:iam::123456789012:user/David"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudformation_stack_invalid_on_failure_test.go
+++ b/rules/models/aws_cloudformation_stack_invalid_on_failure_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudformationStackInvalidOnFailureRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudformation_stack" "foo" {
-	on_failure = "DO_ANYTHING"
-}`,
+	on_failure = DO_NOTHING
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudformation_stack" "foo" {
+	on_failure = DO_ANYTHING
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudformationStackInvalidOnFailureRule(),
-					Message: `"DO_ANYTHING" is an invalid value as on_failure`,
+					Message: `DO_ANYTHING is an invalid value as on_failure`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudformation_stack" "foo" {
-	on_failure = "DO_NOTHING"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudformation_stack_set_instance_invalid_account_id_test.go
+++ b/rules/models/aws_cloudformation_stack_set_instance_invalid_account_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudformationStackSetInstanceInvalidAccountIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudformation_stack_set_instance" "foo" {
-	account_id = "1234567890123"
-}`,
+	account_id = 123456789012
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudformation_stack_set_instance" "foo" {
+	account_id = 1234567890123
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudformationStackSetInstanceInvalidAccountIDRule(),
-					Message: `"1234567890123" does not match valid pattern ^[0-9]{12}$`,
+					Message: `1234567890123 does not match valid pattern ^[0-9]{12}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudformation_stack_set_instance" "foo" {
-	account_id = "123456789012"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudformation_stack_set_invalid_execution_role_name_test.go
+++ b/rules/models/aws_cloudformation_stack_set_invalid_execution_role_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudformationStackSetInvalidExecutionRoleNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudformation_stack_set" "foo" {
-	execution_role_name = "AWSCloudFormation/StackSet/ExecutionRole"
-}`,
+	execution_role_name = AWSCloudFormationStackSetExecutionRole
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudformation_stack_set" "foo" {
+	execution_role_name = AWSCloudFormation/StackSet/ExecutionRole
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudformationStackSetInvalidExecutionRoleNameRule(),
-					Message: `"AWSCloudFormation/StackSet/ExecutionRole" does not match valid pattern ^[a-zA-Z_0-9+=,.@-]+$`,
+					Message: `AWSCloudFormation/StackSet/ExecutionRole does not match valid pattern ^[a-zA-Z_0-9+=,.@-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudformation_stack_set" "foo" {
-	execution_role_name = "AWSCloudFormationStackSetExecutionRole"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudfront_distribution_invalid_http_version_test.go
+++ b/rules/models/aws_cloudfront_distribution_invalid_http_version_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudfrontDistributionInvalidHTTPVersionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudfront_distribution" "foo" {
-	http_version = "http1.2"
-}`,
+	http_version = http2
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudfront_distribution" "foo" {
+	http_version = http1.2
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudfrontDistributionInvalidHTTPVersionRule(),
-					Message: `"http1.2" is an invalid value as http_version`,
+					Message: `http1.2 is an invalid value as http_version`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudfront_distribution" "foo" {
-	http_version = "http2"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudfront_distribution_invalid_price_class_test.go
+++ b/rules/models/aws_cloudfront_distribution_invalid_price_class_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudfrontDistributionInvalidPriceClassRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudfront_distribution" "foo" {
-	price_class = "PriceClass_300"
-}`,
+	price_class = PriceClass_All
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudfront_distribution" "foo" {
+	price_class = PriceClass_300
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudfrontDistributionInvalidPriceClassRule(),
-					Message: `"PriceClass_300" is an invalid value as price_class`,
+					Message: `PriceClass_300 is an invalid value as price_class`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudfront_distribution" "foo" {
-	price_class = "PriceClass_All"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudhsm_v2_cluster_invalid_hsm_type_test.go
+++ b/rules/models/aws_cloudhsm_v2_cluster_invalid_hsm_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudhsmV2ClusterInvalidHsmTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudhsm_v2_cluster" "foo" {
-	hsm_type = "hsm1.micro"
-}`,
+	hsm_type = hsm1.medium
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudhsm_v2_cluster" "foo" {
+	hsm_type = hsm1.micro
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudhsmV2ClusterInvalidHsmTypeRule(),
-					Message: `"hsm1.micro" does not match valid pattern ^(hsm1\.medium)$`,
+					Message: `hsm1.micro does not match valid pattern ^(hsm1\.medium)$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudhsm_v2_cluster" "foo" {
-	hsm_type = "hsm1.medium"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudhsm_v2_cluster_invalid_source_backup_identifier_test.go
+++ b/rules/models/aws_cloudhsm_v2_cluster_invalid_source_backup_identifier_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudhsmV2ClusterInvalidSourceBackupIdentifierRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudhsm_v2_cluster" "foo" {
-	source_backup_identifier = "rtq2dwi2gq6"
-}`,
+	source_backup_identifier = backup-rtq2dwi2gq6
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudhsm_v2_cluster" "foo" {
+	source_backup_identifier = rtq2dwi2gq6
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudhsmV2ClusterInvalidSourceBackupIdentifierRule(),
-					Message: `"rtq2dwi2gq6" does not match valid pattern ^backup-[2-7a-zA-Z]{11,16}$`,
+					Message: `rtq2dwi2gq6 does not match valid pattern ^backup-[2-7a-zA-Z]{11,16}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudhsm_v2_cluster" "foo" {
-	source_backup_identifier = "backup-rtq2dwi2gq6"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudhsm_v2_hsm_invalid_availability_zone_test.go
+++ b/rules/models/aws_cloudhsm_v2_hsm_invalid_availability_zone_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudhsmV2HsmInvalidAvailabilityZoneRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudhsm_v2_hsm" "foo" {
-	availability_zone = "us-east-1"
-}`,
+	availability_zone = us-east-1a
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudhsm_v2_hsm" "foo" {
+	availability_zone = us-east-1
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudhsmV2HsmInvalidAvailabilityZoneRule(),
-					Message: `"us-east-1" does not match valid pattern ^[a-z]{2}(-(gov))?-(east|west|north|south|central){1,2}-\d[a-z]$`,
+					Message: `us-east-1 does not match valid pattern ^[a-z]{2}(-(gov))?-(east|west|north|south|central){1,2}-\d[a-z]$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudhsm_v2_hsm" "foo" {
-	availability_zone = "us-east-1a"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudhsm_v2_hsm_invalid_cluster_id_test.go
+++ b/rules/models/aws_cloudhsm_v2_hsm_invalid_cluster_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudhsmV2HsmInvalidClusterIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudhsm_v2_hsm" "foo" {
-	cluster_id = "jxhlf7644ne"
-}`,
+	cluster_id = cluster-jxhlf7644ne
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudhsm_v2_hsm" "foo" {
+	cluster_id = jxhlf7644ne
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudhsmV2HsmInvalidClusterIDRule(),
-					Message: `"jxhlf7644ne" does not match valid pattern ^cluster-[2-7a-zA-Z]{11,16}$`,
+					Message: `jxhlf7644ne does not match valid pattern ^cluster-[2-7a-zA-Z]{11,16}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudhsm_v2_hsm" "foo" {
-	cluster_id = "cluster-jxhlf7644ne"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudhsm_v2_hsm_invalid_ip_address_test.go
+++ b/rules/models/aws_cloudhsm_v2_hsm_invalid_ip_address_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudhsmV2HsmInvalidIPAddressRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudhsm_v2_hsm" "foo" {
-	ip_address = "2001:4860:4860::8888"
-}`,
+	ip_address = 8.8.8.8
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudhsm_v2_hsm" "foo" {
+	ip_address = 2001:4860:4860::8888
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudhsmV2HsmInvalidIPAddressRule(),
-					Message: `"2001:4860:4860::8888" does not match valid pattern ^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$`,
+					Message: `2001:4860:4860::8888 does not match valid pattern ^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudhsm_v2_hsm" "foo" {
-	ip_address = "8.8.8.8"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudhsm_v2_hsm_invalid_subnet_id_test.go
+++ b/rules/models/aws_cloudhsm_v2_hsm_invalid_subnet_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudhsmV2HsmInvalidSubnetIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudhsm_v2_hsm" "foo" {
-	subnet_id = "0e358c43"
-}`,
+	subnet_id = subnet-0e358c43
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudhsm_v2_hsm" "foo" {
+	subnet_id = 0e358c43
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudhsmV2HsmInvalidSubnetIDRule(),
-					Message: `"0e358c43" does not match valid pattern ^subnet-[0-9a-fA-F]{8,17}$`,
+					Message: `0e358c43 does not match valid pattern ^subnet-[0-9a-fA-F]{8,17}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudhsm_v2_hsm" "foo" {
-	subnet_id = "subnet-0e358c43"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_event_permission_invalid_action_test.go
+++ b/rules/models/aws_cloudwatch_event_permission_invalid_action_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchEventPermissionInvalidActionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_event_permission" "foo" {
-	action = "cloudwatchevents:PutEvents"
-}`,
+	action = events:PutEvents
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_event_permission" "foo" {
+	action = cloudwatchevents:PutEvents
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchEventPermissionInvalidActionRule(),
-					Message: `"cloudwatchevents:PutEvents" does not match valid pattern ^events:[a-zA-Z]+$`,
+					Message: `cloudwatchevents:PutEvents does not match valid pattern ^events:[a-zA-Z]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_event_permission" "foo" {
-	action = "events:PutEvents"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_event_permission_invalid_principal_test.go
+++ b/rules/models/aws_cloudwatch_event_permission_invalid_principal_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchEventPermissionInvalidPrincipalRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_event_permission" "foo" {
-	principal = "-"
-}`,
+	principal = *
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_event_permission" "foo" {
+	principal = -
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchEventPermissionInvalidPrincipalRule(),
-					Message: `"-" does not match valid pattern ^(\d{12}|\*)$`,
+					Message: `- does not match valid pattern ^(\d{12}|\*)$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_event_permission" "foo" {
-	principal = "*"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_event_permission_invalid_statement_id_test.go
+++ b/rules/models/aws_cloudwatch_event_permission_invalid_statement_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchEventPermissionInvalidStatementIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_event_permission" "foo" {
-	statement_id = "Organization Access"
-}`,
+	statement_id = OrganizationAccess
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_event_permission" "foo" {
+	statement_id = Organization Access
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchEventPermissionInvalidStatementIDRule(),
-					Message: `"Organization Access" does not match valid pattern ^[a-zA-Z0-9-_]+$`,
+					Message: `Organization Access does not match valid pattern ^[a-zA-Z0-9-_]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_event_permission" "foo" {
-	statement_id = "OrganizationAccess"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_event_rule_invalid_name_test.go
+++ b/rules/models/aws_cloudwatch_event_rule_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchEventRuleInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_event_rule" "foo" {
-	name = "capture aws sign in"
-}`,
+	name = capture-aws-sign-in
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_event_rule" "foo" {
+	name = capture aws sign in
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchEventRuleInvalidNameRule(),
-					Message: `"capture aws sign in" does not match valid pattern ^[\.\-_A-Za-z0-9]+$`,
+					Message: `capture aws sign in does not match valid pattern ^[\.\-_A-Za-z0-9]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_event_rule" "foo" {
-	name = "capture-aws-sign-in"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_event_target_invalid_target_id_test.go
+++ b/rules/models/aws_cloudwatch_event_target_invalid_target_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchEventTargetInvalidTargetIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_event_target" "foo" {
-	target_id = "run scheduled task every hour"
-}`,
+	target_id = run-scheduled-task-every-hour
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_event_target" "foo" {
+	target_id = run scheduled task every hour
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchEventTargetInvalidTargetIDRule(),
-					Message: `"run scheduled task every hour" does not match valid pattern ^[\.\-_A-Za-z0-9]+$`,
+					Message: `run scheduled task every hour does not match valid pattern ^[\.\-_A-Za-z0-9]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_event_target" "foo" {
-	target_id = "run-scheduled-task-every-hour"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_log_destination_invalid_name_test.go
+++ b/rules/models/aws_cloudwatch_log_destination_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchLogDestinationInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_log_destination" "foo" {
-	name = "test:destination"
-}`,
+	name = test_destination
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_log_destination" "foo" {
+	name = test:destination
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchLogDestinationInvalidNameRule(),
-					Message: `"test:destination" does not match valid pattern ^[^:*]*$`,
+					Message: `test:destination does not match valid pattern ^[^:*]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_log_destination" "foo" {
-	name = "test_destination"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_log_group_invalid_name_test.go
+++ b/rules/models/aws_cloudwatch_log_group_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchLogGroupInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_log_group" "foo" {
-	name = "Yoda:prod"
-}`,
+	name = Yada
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_log_group" "foo" {
+	name = Yoda:prod
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchLogGroupInvalidNameRule(),
-					Message: `"Yoda:prod" does not match valid pattern ^[\.\-_/#A-Za-z0-9]+$`,
+					Message: `Yoda:prod does not match valid pattern ^[\.\-_/#A-Za-z0-9]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_log_group" "foo" {
-	name = "Yada"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_log_metric_filter_invalid_name_test.go
+++ b/rules/models/aws_cloudwatch_log_metric_filter_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchLogMetricFilterInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_log_metric_filter" "foo" {
-	name = "MyAppAccessCount:prod"
-}`,
+	name = MyAppAccessCount
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_log_metric_filter" "foo" {
+	name = MyAppAccessCount:prod
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchLogMetricFilterInvalidNameRule(),
-					Message: `"MyAppAccessCount:prod" does not match valid pattern ^[^:*]*$`,
+					Message: `MyAppAccessCount:prod does not match valid pattern ^[^:*]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_log_metric_filter" "foo" {
-	name = "MyAppAccessCount"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_log_stream_invalid_name_test.go
+++ b/rules/models/aws_cloudwatch_log_stream_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchLogStreamInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_log_stream" "foo" {
-	name = "Yoda:prod"
-}`,
+	name = Yada
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_log_stream" "foo" {
+	name = Yoda:prod
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchLogStreamInvalidNameRule(),
-					Message: `"Yoda:prod" does not match valid pattern ^[^:*]*$`,
+					Message: `Yoda:prod does not match valid pattern ^[^:*]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_log_stream" "foo" {
-	name = "Yada"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_log_subscription_filter_invalid_distribution_test.go
+++ b/rules/models/aws_cloudwatch_log_subscription_filter_invalid_distribution_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchLogSubscriptionFilterInvalidDistributionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_log_subscription_filter" "foo" {
-	distribution = "LogStream"
-}`,
+	distribution = Random
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_log_subscription_filter" "foo" {
+	distribution = LogStream
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchLogSubscriptionFilterInvalidDistributionRule(),
-					Message: `"LogStream" is an invalid value as distribution`,
+					Message: `LogStream is an invalid value as distribution`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_log_subscription_filter" "foo" {
-	distribution = "Random"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_log_subscription_filter_invalid_name_test.go
+++ b/rules/models/aws_cloudwatch_log_subscription_filter_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchLogSubscriptionFilterInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_log_subscription_filter" "foo" {
-	name = "test_lambdafunction_logfilter:test"
-}`,
+	name = test_lambdafunction_logfilter
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_log_subscription_filter" "foo" {
+	name = test_lambdafunction_logfilter:test
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchLogSubscriptionFilterInvalidNameRule(),
-					Message: `"test_lambdafunction_logfilter:test" does not match valid pattern ^[^:*]*$`,
+					Message: `test_lambdafunction_logfilter:test does not match valid pattern ^[^:*]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_log_subscription_filter" "foo" {
-	name = "test_lambdafunction_logfilter"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_metric_alarm_invalid_comparison_operator_test.go
+++ b/rules/models/aws_cloudwatch_metric_alarm_invalid_comparison_operator_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchMetricAlarmInvalidComparisonOperatorRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_metric_alarm" "foo" {
-	comparison_operator = "GreaterThanOrEqual"
-}`,
+	comparison_operator = GreaterThanOrEqualToThreshold
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_metric_alarm" "foo" {
+	comparison_operator = GreaterThanOrEqual
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchMetricAlarmInvalidComparisonOperatorRule(),
-					Message: `"GreaterThanOrEqual" is an invalid value as comparison_operator`,
+					Message: `GreaterThanOrEqual is an invalid value as comparison_operator`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_metric_alarm" "foo" {
-	comparison_operator = "GreaterThanOrEqualToThreshold"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_metric_alarm_invalid_namespace_test.go
+++ b/rules/models/aws_cloudwatch_metric_alarm_invalid_namespace_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchMetricAlarmInvalidNamespaceRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_metric_alarm" "foo" {
-	namespace = ":EC2"
-}`,
+	namespace = AWS/EC2
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_metric_alarm" "foo" {
+	namespace = :EC2
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchMetricAlarmInvalidNamespaceRule(),
-					Message: `":EC2" does not match valid pattern ^[^:].*$`,
+					Message: `:EC2 does not match valid pattern ^[^:].*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_metric_alarm" "foo" {
-	namespace = "AWS/EC2"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_metric_alarm_invalid_statistic_test.go
+++ b/rules/models/aws_cloudwatch_metric_alarm_invalid_statistic_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchMetricAlarmInvalidStatisticRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_metric_alarm" "foo" {
-	statistic = "Median"
-}`,
+	statistic = Average
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_metric_alarm" "foo" {
+	statistic = Median
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchMetricAlarmInvalidStatisticRule(),
-					Message: `"Median" is an invalid value as statistic`,
+					Message: `Median is an invalid value as statistic`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_metric_alarm" "foo" {
-	statistic = "Average"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cloudwatch_metric_alarm_invalid_unit_test.go
+++ b/rules/models/aws_cloudwatch_metric_alarm_invalid_unit_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCloudwatchMetricAlarmInvalidUnitRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cloudwatch_metric_alarm" "foo" {
-	unit = "GB"
-}`,
+	unit = Gigabytes
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cloudwatch_metric_alarm" "foo" {
+	unit = GB
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCloudwatchMetricAlarmInvalidUnitRule(),
-					Message: `"GB" is an invalid value as unit`,
+					Message: `GB is an invalid value as unit`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cloudwatch_metric_alarm" "foo" {
-	unit = "Gigabytes"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_codecommit_repository_invalid_repository_name_test.go
+++ b/rules/models/aws_codecommit_repository_invalid_repository_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCodecommitRepositoryInvalidRepositoryNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_codecommit_repository" "foo" {
-	repository_name = "mytest@repository"
-}`,
+	repository_name = MyTestRepository
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_codecommit_repository" "foo" {
+	repository_name = mytest@repository
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCodecommitRepositoryInvalidRepositoryNameRule(),
-					Message: `"mytest@repository" does not match valid pattern ^[\w\.-]+$`,
+					Message: `mytest@repository does not match valid pattern ^[\w\.-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_codecommit_repository" "foo" {
-	repository_name = "MyTestRepository"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_codedeploy_app_invalid_compute_platform_test.go
+++ b/rules/models/aws_codedeploy_app_invalid_compute_platform_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCodedeployAppInvalidComputePlatformRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_codedeploy_app" "foo" {
-	compute_platform = "Fargate"
-}`,
+	compute_platform = Server
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_codedeploy_app" "foo" {
+	compute_platform = Fargate
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCodedeployAppInvalidComputePlatformRule(),
-					Message: `"Fargate" is an invalid value as compute_platform`,
+					Message: `Fargate is an invalid value as compute_platform`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_codedeploy_app" "foo" {
-	compute_platform = "Server"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_codepipeline_invalid_name_test.go
+++ b/rules/models/aws_codepipeline_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCodepipelineInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_codepipeline" "foo" {
-	name = "test/pipeline"
-}`,
+	name = tf-test-pipeline
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_codepipeline" "foo" {
+	name = test/pipeline
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCodepipelineInvalidNameRule(),
-					Message: `"test/pipeline" does not match valid pattern ^[A-Za-z0-9.@\-_]+$`,
+					Message: `test/pipeline does not match valid pattern ^[A-Za-z0-9.@\-_]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_codepipeline" "foo" {
-	name = "tf-test-pipeline"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_codepipeline_invalid_role_arn_test.go
+++ b/rules/models/aws_codepipeline_invalid_role_arn_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCodepipelineInvalidRoleArnRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_codepipeline" "foo" {
-	role_arn = "arn:aws:iam::123456789012:instance-profile/s3access-profile"
-}`,
+	role_arn = arn:aws:iam::123456789012:role/s3access
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_codepipeline" "foo" {
+	role_arn = arn:aws:iam::123456789012:instance-profile/s3access-profile
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCodepipelineInvalidRoleArnRule(),
-					Message: `"arn:aws:iam::123456789012:instance-profile/s3access-profile" does not match valid pattern ^arn:aws(-[\w]+)*:iam::[0-9]{12}:role/.*$`,
+					Message: `arn:aws:iam::123456789012:instance-profile/s3access-profile does not match valid pattern ^arn:aws(-[\w]+)*:iam::[0-9]{12}:role/.*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_codepipeline" "foo" {
-	role_arn = "arn:aws:iam::123456789012:role/s3access"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_codepipeline_webhook_invalid_authentication_test.go
+++ b/rules/models/aws_codepipeline_webhook_invalid_authentication_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCodepipelineWebhookInvalidAuthenticationRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_codepipeline_webhook" "foo" {
-	authentication = "GITLAB_HMAC"
-}`,
+	authentication = GITHUB_HMAC
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_codepipeline_webhook" "foo" {
+	authentication = GITLAB_HMAC
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCodepipelineWebhookInvalidAuthenticationRule(),
-					Message: `"GITLAB_HMAC" is an invalid value as authentication`,
+					Message: `GITLAB_HMAC is an invalid value as authentication`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_codepipeline_webhook" "foo" {
-	authentication = "GITHUB_HMAC"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_codepipeline_webhook_invalid_name_test.go
+++ b/rules/models/aws_codepipeline_webhook_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCodepipelineWebhookInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_codepipeline_webhook" "foo" {
-	name = "webhook-github-bar/testing"
-}`,
+	name = test-webhook-github-bar
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_codepipeline_webhook" "foo" {
+	name = webhook-github-bar/testing
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCodepipelineWebhookInvalidNameRule(),
-					Message: `"webhook-github-bar/testing" does not match valid pattern ^[A-Za-z0-9.@\-_]+$`,
+					Message: `webhook-github-bar/testing does not match valid pattern ^[A-Za-z0-9.@\-_]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_codepipeline_webhook" "foo" {
-	name = "test-webhook-github-bar"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_codepipeline_webhook_invalid_target_action_test.go
+++ b/rules/models/aws_codepipeline_webhook_invalid_target_action_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCodepipelineWebhookInvalidTargetActionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_codepipeline_webhook" "foo" {
-	target_action = "Source/Example"
-}`,
+	target_action = Source
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_codepipeline_webhook" "foo" {
+	target_action = Source/Example
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCodepipelineWebhookInvalidTargetActionRule(),
-					Message: `"Source/Example" does not match valid pattern ^[A-Za-z0-9.@\-_]+$`,
+					Message: `Source/Example does not match valid pattern ^[A-Za-z0-9.@\-_]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_codepipeline_webhook" "foo" {
-	target_action = "Source"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_identity_pool_invalid_identity_pool_name_test.go
+++ b/rules/models/aws_cognito_identity_pool_invalid_identity_pool_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoIdentityPoolInvalidIdentityPoolNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_identity_pool" "foo" {
-	identity_pool_name = "identity:pool"
-}`,
+	identity_pool_name = identity pool
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_identity_pool" "foo" {
+	identity_pool_name = identity:pool
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoIdentityPoolInvalidIdentityPoolNameRule(),
-					Message: `"identity:pool" does not match valid pattern ^[\w\s+=,.@-]+$`,
+					Message: `identity:pool does not match valid pattern ^[\w\s+=,.@-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_identity_pool" "foo" {
-	identity_pool_name = "identity pool"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_identity_pool_roles_attachment_invalid_identity_pool_id_test.go
+++ b/rules/models/aws_cognito_identity_pool_roles_attachment_invalid_identity_pool_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoIdentityPoolRolesAttachmentInvalidIdentityPoolIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_identity_pool_roles_attachment" "foo" {
-	identity_pool_id = "0123456789"
-}`,
+	identity_pool_id = us-east-1:0123456789
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_identity_pool_roles_attachment" "foo" {
+	identity_pool_id = 0123456789
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoIdentityPoolRolesAttachmentInvalidIdentityPoolIDRule(),
-					Message: `"0123456789" does not match valid pattern ^[\w-]+:[0-9a-f-]+$`,
+					Message: `0123456789 does not match valid pattern ^[\w-]+:[0-9a-f-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_identity_pool_roles_attachment" "foo" {
-	identity_pool_id = "us-east-1:0123456789"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_identity_provider_invalid_provider_name_test.go
+++ b/rules/models/aws_cognito_identity_provider_invalid_provider_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoIdentityProviderInvalidProviderNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_identity_provider" "foo" {
-	provider_name = "	"
-}`,
+	provider_name = Google
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_identity_provider" "foo" {
+	provider_name = 	
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoIdentityProviderInvalidProviderNameRule(),
-					Message: `"	" does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$`,
+					Message: `	 does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_identity_provider" "foo" {
-	provider_name = "Google"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_identity_provider_invalid_provider_type_test.go
+++ b/rules/models/aws_cognito_identity_provider_invalid_provider_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoIdentityProviderInvalidProviderTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_identity_provider" "foo" {
-	provider_type = "Apple"
-}`,
+	provider_type = LoginWithAmazon
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_identity_provider" "foo" {
+	provider_type = Apple
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoIdentityProviderInvalidProviderTypeRule(),
-					Message: `"Apple" is an invalid value as provider_type`,
+					Message: `Apple is an invalid value as provider_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_identity_provider" "foo" {
-	provider_type = "LoginWithAmazon"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_identity_provider_invalid_user_pool_id_test.go
+++ b/rules/models/aws_cognito_identity_provider_invalid_user_pool_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoIdentityProviderInvalidUserPoolIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_identity_provider" "foo" {
-	user_pool_id = "foobar"
-}`,
+	user_pool_id = foo_bar
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_identity_provider" "foo" {
+	user_pool_id = foobar
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoIdentityProviderInvalidUserPoolIDRule(),
-					Message: `"foobar" does not match valid pattern ^[\w-]+_[0-9a-zA-Z]+$`,
+					Message: `foobar does not match valid pattern ^[\w-]+_[0-9a-zA-Z]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_identity_provider" "foo" {
-	user_pool_id = "foo_bar"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_resource_server_invalid_identifier_test.go
+++ b/rules/models/aws_cognito_resource_server_invalid_identifier_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoResourceServerInvalidIdentifierRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_resource_server" "foo" {
-	identifier = "	"
-}`,
+	identifier = https://example.com
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_resource_server" "foo" {
+	identifier = 	
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoResourceServerInvalidIdentifierRule(),
-					Message: `"	" does not match valid pattern ^[\x21\x23-\x5B\x5D-\x7E]+$`,
+					Message: `	 does not match valid pattern ^[\x21\x23-\x5B\x5D-\x7E]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_resource_server" "foo" {
-	identifier = "https://example.com"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_resource_server_invalid_name_test.go
+++ b/rules/models/aws_cognito_resource_server_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoResourceServerInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_resource_server" "foo" {
-	name = "example/server"
-}`,
+	name = example
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_resource_server" "foo" {
+	name = example/server
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoResourceServerInvalidNameRule(),
-					Message: `"example/server" does not match valid pattern ^[\w\s+=,.@-]+$`,
+					Message: `example/server does not match valid pattern ^[\w\s+=,.@-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_resource_server" "foo" {
-	name = "example"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_group_invalid_name_test.go
+++ b/rules/models/aws_cognito_user_group_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserGroupInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_group" "foo" {
-	name = "user	group"
-}`,
+	name = user-group
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_group" "foo" {
+	name = user	group
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserGroupInvalidNameRule(),
-					Message: `"user	group" does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$`,
+					Message: `user	group does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_group" "foo" {
-	name = "user-group"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_group_invalid_role_arn_test.go
+++ b/rules/models/aws_cognito_user_group_invalid_role_arn_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserGroupInvalidRoleArnRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_group" "foo" {
-	role_arn = "aws:iam::123456789012:instance-profile/s3access-profile"
-}`,
+	role_arn = arn:aws:iam::123456789012:role/s3access
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_group" "foo" {
+	role_arn = aws:iam::123456789012:instance-profile/s3access-profile
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserGroupInvalidRoleArnRule(),
-					Message: `"aws:iam::123456789012:instance-profile/s3access-profile" does not match valid pattern ^arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=/,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?$`,
+					Message: `aws:iam::123456789012:instance-profile/s3access-profile does not match valid pattern ^arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=/,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_group" "foo" {
-	role_arn = "arn:aws:iam::123456789012:role/s3access"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_pool_client_invalid_default_redirect_uri_test.go
+++ b/rules/models/aws_cognito_user_pool_client_invalid_default_redirect_uri_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserPoolClientInvalidDefaultRedirectURIRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_pool_client" "foo" {
-	default_redirect_uri = "https://example com"
-}`,
+	default_redirect_uri = https://example.com/callback
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_pool_client" "foo" {
+	default_redirect_uri = https://example com
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolClientInvalidDefaultRedirectURIRule(),
-					Message: `"https://example com" does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$`,
+					Message: `https://example com does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_pool_client" "foo" {
-	default_redirect_uri = "https://example.com/callback"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_pool_client_invalid_name_test.go
+++ b/rules/models/aws_cognito_user_pool_client_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserPoolClientInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_pool_client" "foo" {
-	name = "client/example"
-}`,
+	name = client
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_pool_client" "foo" {
+	name = client/example
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolClientInvalidNameRule(),
-					Message: `"client/example" does not match valid pattern ^[\w\s+=,.@-]+$`,
+					Message: `client/example does not match valid pattern ^[\w\s+=,.@-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_pool_client" "foo" {
-	name = "client"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_pool_invalid_email_verification_message_test.go
+++ b/rules/models/aws_cognito_user_pool_invalid_email_verification_message_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserPoolInvalidEmailVerificationMessageRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_pool" "foo" {
-	email_verification_message = "Verification code"
-}`,
+	email_verification_message = Verification code is {####}
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_pool" "foo" {
+	email_verification_message = Verification code
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolInvalidEmailVerificationMessageRule(),
-					Message: `"Verification code" does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*$`,
+					Message: `Verification code does not match valid pattern ^[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{####\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_pool" "foo" {
-	email_verification_message = "Verification code is {####}"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_pool_invalid_mfa_configuration_test.go
+++ b/rules/models/aws_cognito_user_pool_invalid_mfa_configuration_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserPoolInvalidMfaConfigurationRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_pool" "foo" {
-	mfa_configuration = "IN"
-}`,
+	mfa_configuration = ON
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_pool" "foo" {
+	mfa_configuration = IN
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolInvalidMfaConfigurationRule(),
-					Message: `"IN" is an invalid value as mfa_configuration`,
+					Message: `IN is an invalid value as mfa_configuration`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_pool" "foo" {
-	mfa_configuration = "ON"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_pool_invalid_name_test.go
+++ b/rules/models/aws_cognito_user_pool_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserPoolInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_pool" "foo" {
-	name = "my/pool"
-}`,
+	name = mypool
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_pool" "foo" {
+	name = my/pool
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolInvalidNameRule(),
-					Message: `"my/pool" does not match valid pattern ^[\w\s+=,.@-]+$`,
+					Message: `my/pool does not match valid pattern ^[\w\s+=,.@-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_pool" "foo" {
-	name = "mypool"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_pool_invalid_sms_authentication_message_test.go
+++ b/rules/models/aws_cognito_user_pool_invalid_sms_authentication_message_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserPoolInvalidSmsAuthenticationMessageRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_pool" "foo" {
-	sms_authentication_message = "Authentication code"
-}`,
+	sms_authentication_message = Authentication code is {####}
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_pool" "foo" {
+	sms_authentication_message = Authentication code
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolInvalidSmsAuthenticationMessageRule(),
-					Message: `"Authentication code" does not match valid pattern ^.*\{####\}.*$`,
+					Message: `Authentication code does not match valid pattern ^.*\{####\}.*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_pool" "foo" {
-	sms_authentication_message = "Authentication code is {####}"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cognito_user_pool_invalid_sms_verification_message_test.go
+++ b/rules/models/aws_cognito_user_pool_invalid_sms_verification_message_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCognitoUserPoolInvalidSmsVerificationMessageRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cognito_user_pool" "foo" {
-	sms_verification_message = "Verification code"
-}`,
+	sms_verification_message = Verification code is {####}
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cognito_user_pool" "foo" {
+	sms_verification_message = Verification code
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolInvalidSmsVerificationMessageRule(),
-					Message: `"Verification code" does not match valid pattern ^.*\{####\}.*$`,
+					Message: `Verification code does not match valid pattern ^.*\{####\}.*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cognito_user_pool" "foo" {
-	sms_verification_message = "Verification code is {####}"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_config_aggregate_authorization_invalid_account_id_test.go
+++ b/rules/models/aws_config_aggregate_authorization_invalid_account_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsConfigAggregateAuthorizationInvalidAccountIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_config_aggregate_authorization" "foo" {
-	account_id = "01234567891"
-}`,
+	account_id = 012345678910
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_config_aggregate_authorization" "foo" {
+	account_id = 01234567891
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsConfigAggregateAuthorizationInvalidAccountIDRule(),
-					Message: `"01234567891" does not match valid pattern ^\d{12}$`,
+					Message: `01234567891 does not match valid pattern ^\d{12}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_config_aggregate_authorization" "foo" {
-	account_id = "012345678910"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_config_config_rule_invalid_maximum_execution_frequency_test.go
+++ b/rules/models/aws_config_config_rule_invalid_maximum_execution_frequency_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsConfigConfigRuleInvalidMaximumExecutionFrequencyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_config_config_rule" "foo" {
-	maximum_execution_frequency = "Hour"
-}`,
+	maximum_execution_frequency = One_Hour
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_config_config_rule" "foo" {
+	maximum_execution_frequency = Hour
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsConfigConfigRuleInvalidMaximumExecutionFrequencyRule(),
-					Message: `"Hour" is an invalid value as maximum_execution_frequency`,
+					Message: `Hour is an invalid value as maximum_execution_frequency`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_config_config_rule" "foo" {
-	maximum_execution_frequency = "One_Hour"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_config_configuration_aggregator_invalid_name_test.go
+++ b/rules/models/aws_config_configuration_aggregator_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsConfigConfigurationAggregatorInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_config_configuration_aggregator" "foo" {
-	name = "example.com"
-}`,
+	name = example
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_config_configuration_aggregator" "foo" {
+	name = example.com
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsConfigConfigurationAggregatorInvalidNameRule(),
-					Message: `"example.com" does not match valid pattern ^[\w\-]+$`,
+					Message: `example.com does not match valid pattern ^[\w\-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_config_configuration_aggregator" "foo" {
-	name = "example"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cur_report_definition_invalid_compression_test.go
+++ b/rules/models/aws_cur_report_definition_invalid_compression_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCurReportDefinitionInvalidCompressionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cur_report_definition" "foo" {
-	compression = "TAR"
-}`,
+	compression = ZIP
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cur_report_definition" "foo" {
+	compression = TAR
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCurReportDefinitionInvalidCompressionRule(),
-					Message: `"TAR" is an invalid value as compression`,
+					Message: `TAR is an invalid value as compression`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cur_report_definition" "foo" {
-	compression = "ZIP"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cur_report_definition_invalid_format_test.go
+++ b/rules/models/aws_cur_report_definition_invalid_format_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCurReportDefinitionInvalidFormatRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cur_report_definition" "foo" {
-	format = "textORjson"
-}`,
+	format = textORcsv
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cur_report_definition" "foo" {
+	format = textORjson
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCurReportDefinitionInvalidFormatRule(),
-					Message: `"textORjson" is an invalid value as format`,
+					Message: `textORjson is an invalid value as format`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cur_report_definition" "foo" {
-	format = "textORcsv"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cur_report_definition_invalid_report_name_test.go
+++ b/rules/models/aws_cur_report_definition_invalid_report_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCurReportDefinitionInvalidReportNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cur_report_definition" "foo" {
-	report_name = "example/cur-report-definition"
-}`,
+	report_name = example-cur-report-definition
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cur_report_definition" "foo" {
+	report_name = example/cur-report-definition
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCurReportDefinitionInvalidReportNameRule(),
-					Message: `"example/cur-report-definition" does not match valid pattern ^[0-9A-Za-z!\-_.*\'()]+$`,
+					Message: `example/cur-report-definition does not match valid pattern ^[0-9A-Za-z!\-_.*\'()]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cur_report_definition" "foo" {
-	report_name = "example-cur-report-definition"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cur_report_definition_invalid_s3_region_test.go
+++ b/rules/models/aws_cur_report_definition_invalid_s3_region_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCurReportDefinitionInvalidS3RegionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cur_report_definition" "foo" {
-	s3_region = "us-gov-east-1"
-}`,
+	s3_region = us-east-1
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cur_report_definition" "foo" {
+	s3_region = us-gov-east-1
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCurReportDefinitionInvalidS3RegionRule(),
-					Message: `"us-gov-east-1" is an invalid value as s3_region`,
+					Message: `us-gov-east-1 is an invalid value as s3_region`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cur_report_definition" "foo" {
-	s3_region = "us-east-1"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_cur_report_definition_invalid_time_unit_test.go
+++ b/rules/models/aws_cur_report_definition_invalid_time_unit_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsCurReportDefinitionInvalidTimeUnitRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_cur_report_definition" "foo" {
-	time_unit = "FORNIGHTLY"
-}`,
+	time_unit = HOURLY
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_cur_report_definition" "foo" {
+	time_unit = FORNIGHTLY
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsCurReportDefinitionInvalidTimeUnitRule(),
-					Message: `"FORNIGHTLY" is an invalid value as time_unit`,
+					Message: `FORNIGHTLY is an invalid value as time_unit`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_cur_report_definition" "foo" {
-	time_unit = "HOURLY"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_agent_invalid_activation_key_test.go
+++ b/rules/models/aws_datasync_agent_invalid_activation_key_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncAgentInvalidActivationKeyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_agent" "foo" {
-	activation_key = "F0EFT7FPPRGG7MC3I9R327DOH"
-}`,
+	activation_key = F0EFT-7FPPR-GG7MC-3I9R3-27DOH
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_agent" "foo" {
+	activation_key = F0EFT7FPPRGG7MC3I9R327DOH
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncAgentInvalidActivationKeyRule(),
-					Message: `"F0EFT7FPPRGG7MC3I9R327DOH" does not match valid pattern ^[A-Z0-9]{5}(-[A-Z0-9]{5}){4}$`,
+					Message: `F0EFT7FPPRGG7MC3I9R327DOH does not match valid pattern ^[A-Z0-9]{5}(-[A-Z0-9]{5}){4}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_agent" "foo" {
-	activation_key = "F0EFT-7FPPR-GG7MC-3I9R3-27DOH"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_agent_invalid_name_test.go
+++ b/rules/models/aws_datasync_agent_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncAgentInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_agent" "foo" {
-	name = "example^example"
-}`,
+	name = example
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_agent" "foo" {
+	name = example^example
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncAgentInvalidNameRule(),
-					Message: `"example^example" does not match valid pattern ^[a-zA-Z0-9\s+=._:@/-]+$`,
+					Message: `example^example does not match valid pattern ^[a-zA-Z0-9\s+=._:@/-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_agent" "foo" {
-	name = "example"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_location_efs_invalid_efs_file_system_arn_test.go
+++ b/rules/models/aws_datasync_location_efs_invalid_efs_file_system_arn_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncLocationEfsInvalidEfsFileSystemArnRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_location_efs" "foo" {
-	efs_file_system_arn = "arn:aws:eks:us-east-1:123456789012:cluster/my-cluster"
-}`,
+	efs_file_system_arn = arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-12345678
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_location_efs" "foo" {
+	efs_file_system_arn = arn:aws:eks:us-east-1:123456789012:cluster/my-cluster
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncLocationEfsInvalidEfsFileSystemArnRule(),
-					Message: `"arn:aws:eks:us-east-1:123456789012:cluster/my-cluster" does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):elasticfilesystem:[a-z\-0-9]*:[0-9]{12}:file-system/fs-.*$`,
+					Message: `arn:aws:eks:us-east-1:123456789012:cluster/my-cluster does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):elasticfilesystem:[a-z\-0-9]*:[0-9]{12}:file-system/fs-.*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_location_efs" "foo" {
-	efs_file_system_arn = "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-12345678"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_location_efs_invalid_subdirectory_test.go
+++ b/rules/models/aws_datasync_location_efs_invalid_subdirectory_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncLocationEfsInvalidSubdirectoryRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_location_efs" "foo" {
-	subdirectory = "bar	"
-}`,
+	subdirectory = foo
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_location_efs" "foo" {
+	subdirectory = bar	
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncLocationEfsInvalidSubdirectoryRule(),
-					Message: `"bar	" does not match valid pattern ^[a-zA-Z0-9_\-\+\./\(\)\p{Zs}]*$`,
+					Message: `bar	 does not match valid pattern ^[a-zA-Z0-9_\-\+\./\(\)\p{Zs}]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_location_efs" "foo" {
-	subdirectory = "foo"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_location_nfs_invalid_server_hostname_test.go
+++ b/rules/models/aws_datasync_location_nfs_invalid_server_hostname_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncLocationNfsInvalidServerHostnameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_location_nfs" "foo" {
-	server_hostname = "nfs^example^com"
-}`,
+	server_hostname = nfs.example.com
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_location_nfs" "foo" {
+	server_hostname = nfs^example^com
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncLocationNfsInvalidServerHostnameRule(),
-					Message: `"nfs^example^com" does not match valid pattern ^(([a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9\-]*[A-Za-z0-9])$`,
+					Message: `nfs^example^com does not match valid pattern ^(([a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9\-]*[A-Za-z0-9])$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_location_nfs" "foo" {
-	server_hostname = "nfs.example.com"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_location_nfs_invalid_subdirectory_test.go
+++ b/rules/models/aws_datasync_location_nfs_invalid_subdirectory_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncLocationNfsInvalidSubdirectoryRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_location_nfs" "foo" {
-	subdirectory = "/exported^path"
-}`,
+	subdirectory = /exported/path
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_location_nfs" "foo" {
+	subdirectory = /exported^path
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncLocationNfsInvalidSubdirectoryRule(),
-					Message: `"/exported^path" does not match valid pattern ^[a-zA-Z0-9_\-\+\./\(\)\p{Zs}]*$`,
+					Message: `/exported^path does not match valid pattern ^[a-zA-Z0-9_\-\+\./\(\)\p{Zs}]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_location_nfs" "foo" {
-	subdirectory = "/exported/path"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_location_s3_invalid_s3_bucket_arn_test.go
+++ b/rules/models/aws_datasync_location_s3_invalid_s3_bucket_arn_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncLocationS3InvalidS3BucketArnRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_location_s3" "foo" {
-	s3_bucket_arn = "arn:aws:eks:us-east-1:123456789012:cluster/my-cluster"
-}`,
+	s3_bucket_arn = arn:aws:s3:::my_corporate_bucket
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_location_s3" "foo" {
+	s3_bucket_arn = arn:aws:eks:us-east-1:123456789012:cluster/my-cluster
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncLocationS3InvalidS3BucketArnRule(),
-					Message: `"arn:aws:eks:us-east-1:123456789012:cluster/my-cluster" does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):(s3|s3-outposts):[a-z\-0-9]*:[0-9]*:.*$`,
+					Message: `arn:aws:eks:us-east-1:123456789012:cluster/my-cluster does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):(s3|s3-outposts):[a-z\-0-9]*:[0-9]*:.*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_location_s3" "foo" {
-	s3_bucket_arn = "arn:aws:s3:::my_corporate_bucket"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_task_invalid_cloudwatch_log_group_arn_test.go
+++ b/rules/models/aws_datasync_task_invalid_cloudwatch_log_group_arn_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncTaskInvalidCloudwatchLogGroupArnRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_task" "foo" {
-	cloudwatch_log_group_arn = "arn:aws:s3:::my_corporate_bucket"
-}`,
+	cloudwatch_log_group_arn = arn:aws:logs:us-east-1:123456789012:log-group:my-log-group
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_task" "foo" {
+	cloudwatch_log_group_arn = arn:aws:s3:::my_corporate_bucket
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncTaskInvalidCloudwatchLogGroupArnRule(),
-					Message: `"arn:aws:s3:::my_corporate_bucket" does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):logs:[a-z\-0-9]*:[0-9]{12}:log-group:([^:\*]*)(:\*)?$`,
+					Message: `arn:aws:s3:::my_corporate_bucket does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):logs:[a-z\-0-9]*:[0-9]{12}:log-group:([^:\*]*)(:\*)?$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_task" "foo" {
-	cloudwatch_log_group_arn = "arn:aws:logs:us-east-1:123456789012:log-group:my-log-group"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_datasync_task_invalid_source_location_arn_test.go
+++ b/rules/models/aws_datasync_task_invalid_source_location_arn_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDatasyncTaskInvalidSourceLocationArnRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_datasync_task" "foo" {
-	source_location_arn = "arn:aws:datasync:us-east-2:111222333444:task/task-08de6e6697796f026"
-}`,
+	source_location_arn = arn:aws:datasync:us-east-2:111222333444:location/loc-07db7abfc326c50fb
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_datasync_task" "foo" {
+	source_location_arn = arn:aws:datasync:us-east-2:111222333444:task/task-08de6e6697796f026
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDatasyncTaskInvalidSourceLocationArnRule(),
-					Message: `"arn:aws:datasync:us-east-2:111222333444:task/task-08de6e6697796f026" does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):datasync:[a-z\-0-9]+:[0-9]{12}:location/loc-[0-9a-z]{17}$`,
+					Message: `arn:aws:datasync:us-east-2:111222333444:task/task-08de6e6697796f026 does not match valid pattern ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b):datasync:[a-z\-0-9]+:[0-9]{12}:location/loc-[0-9a-z]{17}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_datasync_task" "foo" {
-	source_location_arn = "arn:aws:datasync:us-east-2:111222333444:location/loc-07db7abfc326c50fb"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_conditional_forwarder_invalid_directory_id_test.go
+++ b/rules/models/aws_directory_service_conditional_forwarder_invalid_directory_id_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceConditionalForwarderInvalidDirectoryIDRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_conditional_forwarder" "foo" {
-	directory_id = "1234567890"
-}`,
+	directory_id = d-1234567890
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_conditional_forwarder" "foo" {
+	directory_id = 1234567890
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceConditionalForwarderInvalidDirectoryIDRule(),
-					Message: `"1234567890" does not match valid pattern ^d-[0-9a-f]{10}$`,
+					Message: `1234567890 does not match valid pattern ^d-[0-9a-f]{10}$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_conditional_forwarder" "foo" {
-	directory_id = "d-1234567890"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_conditional_forwarder_invalid_remote_domain_name_test.go
+++ b/rules/models/aws_directory_service_conditional_forwarder_invalid_remote_domain_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceConditionalForwarderInvalidRemoteDomainNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_conditional_forwarder" "foo" {
-	remote_domain_name = "example^com"
-}`,
+	remote_domain_name = example.com
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_conditional_forwarder" "foo" {
+	remote_domain_name = example^com
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceConditionalForwarderInvalidRemoteDomainNameRule(),
-					Message: `"example^com" does not match valid pattern ^([a-zA-Z0-9]+[\\.-])+([a-zA-Z0-9])+[.]?$`,
+					Message: `example^com does not match valid pattern ^([a-zA-Z0-9]+[\\.-])+([a-zA-Z0-9])+[.]?$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_conditional_forwarder" "foo" {
-	remote_domain_name = "example.com"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_directory_invalid_description_test.go
+++ b/rules/models/aws_directory_service_directory_invalid_description_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceDirectoryInvalidDescriptionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_directory" "foo" {
-	description = "@example"
-}`,
+	description = example
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_directory" "foo" {
+	description = @example
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceDirectoryInvalidDescriptionRule(),
-					Message: `"@example" does not match valid pattern ^([a-zA-Z0-9_])[\\a-zA-Z0-9_@#%*+=:?./!\s-]*$`,
+					Message: `@example does not match valid pattern ^([a-zA-Z0-9_])[\\a-zA-Z0-9_@#%*+=:?./!\s-]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_directory" "foo" {
-	description = "example"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_directory_invalid_edition_test.go
+++ b/rules/models/aws_directory_service_directory_invalid_edition_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceDirectoryInvalidEditionRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_directory" "foo" {
-	edition = "Free"
-}`,
+	edition = Enterprise
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_directory" "foo" {
+	edition = Free
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceDirectoryInvalidEditionRule(),
-					Message: `"Free" is an invalid value as edition`,
+					Message: `Free is an invalid value as edition`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_directory" "foo" {
-	edition = "Enterprise"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_directory_invalid_name_test.go
+++ b/rules/models/aws_directory_service_directory_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceDirectoryInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_directory" "foo" {
-	name = "@example.com"
-}`,
+	name = corp.notexample.com
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_directory" "foo" {
+	name = @example.com
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceDirectoryInvalidNameRule(),
-					Message: `"@example.com" does not match valid pattern ^([a-zA-Z0-9]+[\\.-])+([a-zA-Z0-9])+$`,
+					Message: `@example.com does not match valid pattern ^([a-zA-Z0-9]+[\\.-])+([a-zA-Z0-9])+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_directory" "foo" {
-	name = "corp.notexample.com"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_directory_invalid_short_name_test.go
+++ b/rules/models/aws_directory_service_directory_invalid_short_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceDirectoryInvalidShortNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_directory" "foo" {
-	short_name = "CORP:EXAMPLE"
-}`,
+	short_name = CORP
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_directory" "foo" {
+	short_name = CORP:EXAMPLE
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceDirectoryInvalidShortNameRule(),
-					Message: `"CORP:EXAMPLE" does not match valid pattern ^[^\\/:*?"<>|.]+[^\\/:*?"<>|]*$`,
+					Message: `CORP:EXAMPLE does not match valid pattern ^[^\\/:*?"<>|.]+[^\\/:*?"<>|]*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_directory" "foo" {
-	short_name = "CORP"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_directory_invalid_size_test.go
+++ b/rules/models/aws_directory_service_directory_invalid_size_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceDirectoryInvalidSizeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_directory" "foo" {
-	size = "Micro"
-}`,
+	size = Small
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_directory" "foo" {
+	size = Micro
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceDirectoryInvalidSizeRule(),
-					Message: `"Micro" is an invalid value as size`,
+					Message: `Micro is an invalid value as size`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_directory" "foo" {
-	size = "Small"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_directory_service_directory_invalid_type_test.go
+++ b/rules/models/aws_directory_service_directory_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDirectoryServiceDirectoryInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_directory_service_directory" "foo" {
-	type = "ActiveDirectory"
-}`,
+	type = SimpleAD
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_directory_service_directory" "foo" {
+	type = ActiveDirectory
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDirectoryServiceDirectoryInvalidTypeRule(),
-					Message: `"ActiveDirectory" is an invalid value as type`,
+					Message: `ActiveDirectory is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_directory_service_directory" "foo" {
-	type = "SimpleAD"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_dlm_lifecycle_policy_invalid_state_test.go
+++ b/rules/models/aws_dlm_lifecycle_policy_invalid_state_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDlmLifecyclePolicyInvalidStateRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_dlm_lifecycle_policy" "foo" {
-	state = "ERROR"
-}`,
+	state = ENABLED
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_dlm_lifecycle_policy" "foo" {
+	state = ERROR
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDlmLifecyclePolicyInvalidStateRule(),
-					Message: `"ERROR" is an invalid value as state`,
+					Message: `ERROR is an invalid value as state`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_dlm_lifecycle_policy" "foo" {
-	state = "ENABLED"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_dms_endpoint_invalid_endpoint_type_test.go
+++ b/rules/models/aws_dms_endpoint_invalid_endpoint_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDmsEndpointInvalidEndpointTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_dms_endpoint" "foo" {
-	endpoint_type = "resource"
-}`,
+	endpoint_type = source
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_dms_endpoint" "foo" {
+	endpoint_type = resource
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDmsEndpointInvalidEndpointTypeRule(),
-					Message: `"resource" is an invalid value as endpoint_type`,
+					Message: `resource is an invalid value as endpoint_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_dms_endpoint" "foo" {
-	endpoint_type = "source"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_dms_endpoint_invalid_ssl_mode_test.go
+++ b/rules/models/aws_dms_endpoint_invalid_ssl_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDmsEndpointInvalidSslModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_dms_endpoint" "foo" {
-	ssl_mode = "verify-require"
-}`,
+	ssl_mode = require
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_dms_endpoint" "foo" {
+	ssl_mode = verify-require
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDmsEndpointInvalidSslModeRule(),
-					Message: `"verify-require" is an invalid value as ssl_mode`,
+					Message: `verify-require is an invalid value as ssl_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_dms_endpoint" "foo" {
-	ssl_mode = "require"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_dms_replication_task_invalid_migration_type_test.go
+++ b/rules/models/aws_dms_replication_task_invalid_migration_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDmsReplicationTaskInvalidMigrationTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_dms_replication_task" "foo" {
-	migration_type = "partial-load"
-}`,
+	migration_type = full-load
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_dms_replication_task" "foo" {
+	migration_type = partial-load
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDmsReplicationTaskInvalidMigrationTypeRule(),
-					Message: `"partial-load" is an invalid value as migration_type`,
+					Message: `partial-load is an invalid value as migration_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_dms_replication_task" "foo" {
-	migration_type = "full-load"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_dx_bgp_peer_invalid_address_family_test.go
+++ b/rules/models/aws_dx_bgp_peer_invalid_address_family_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDxBgpPeerInvalidAddressFamilyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_dx_bgp_peer" "foo" {
-	address_family = "ipv2"
-}`,
+	address_family = ipv4
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_dx_bgp_peer" "foo" {
+	address_family = ipv2
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDxBgpPeerInvalidAddressFamilyRule(),
-					Message: `"ipv2" is an invalid value as address_family`,
+					Message: `ipv2 is an invalid value as address_family`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_dx_bgp_peer" "foo" {
-	address_family = "ipv4"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_dynamodb_global_table_invalid_name_test.go
+++ b/rules/models/aws_dynamodb_global_table_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDynamoDBGlobalTableInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_dynamodb_global_table" "foo" {
-	name = "myTable@development"
-}`,
+	name = myTable
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_dynamodb_global_table" "foo" {
+	name = myTable@development
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDynamoDBGlobalTableInvalidNameRule(),
-					Message: `"myTable@development" does not match valid pattern ^[a-zA-Z0-9_.-]+$`,
+					Message: `myTable@development does not match valid pattern ^[a-zA-Z0-9_.-]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_dynamodb_global_table" "foo" {
-	name = "myTable"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_dynamodb_table_invalid_billing_mode_test.go
+++ b/rules/models/aws_dynamodb_table_invalid_billing_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsDynamoDBTableInvalidBillingModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_dynamodb_table" "foo" {
-	billing_mode = "FLEXIBLE"
-}`,
+	billing_mode = PROVISIONED
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_dynamodb_table" "foo" {
+	billing_mode = FLEXIBLE
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsDynamoDBTableInvalidBillingModeRule(),
-					Message: `"FLEXIBLE" is an invalid value as billing_mode`,
+					Message: `FLEXIBLE is an invalid value as billing_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_dynamodb_table" "foo" {
-	billing_mode = "PROVISIONED"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ebs_volume_invalid_type_test.go
+++ b/rules/models/aws_ebs_volume_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEbsVolumeInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ebs_volume" "foo" {
-	type = "gp1"
-}`,
+	type = gp2
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ebs_volume" "foo" {
+	type = gp1
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEbsVolumeInvalidTypeRule(),
-					Message: `"gp1" is an invalid value as type`,
+					Message: `gp1 is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ebs_volume" "foo" {
-	type = "gp2"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_capacity_reservation_invalid_end_date_type_test.go
+++ b/rules/models/aws_ec2_capacity_reservation_invalid_end_date_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2CapacityReservationInvalidEndDateTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_capacity_reservation" "foo" {
-	end_date_type = "unlimit"
-}`,
+	end_date_type = unlimited
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_capacity_reservation" "foo" {
+	end_date_type = unlimit
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2CapacityReservationInvalidEndDateTypeRule(),
-					Message: `"unlimit" is an invalid value as end_date_type`,
+					Message: `unlimit is an invalid value as end_date_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_capacity_reservation" "foo" {
-	end_date_type = "unlimited"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_capacity_reservation_invalid_instance_match_criteria_test.go
+++ b/rules/models/aws_ec2_capacity_reservation_invalid_instance_match_criteria_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2CapacityReservationInvalidInstanceMatchCriteriaRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_capacity_reservation" "foo" {
-	instance_match_criteria = "close"
-}`,
+	instance_match_criteria = open
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_capacity_reservation" "foo" {
+	instance_match_criteria = close
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2CapacityReservationInvalidInstanceMatchCriteriaRule(),
-					Message: `"close" is an invalid value as instance_match_criteria`,
+					Message: `close is an invalid value as instance_match_criteria`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_capacity_reservation" "foo" {
-	instance_match_criteria = "open"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_capacity_reservation_invalid_instance_platform_test.go
+++ b/rules/models/aws_ec2_capacity_reservation_invalid_instance_platform_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2CapacityReservationInvalidInstancePlatformRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_capacity_reservation" "foo" {
-	instance_platform = "Linux/GNU"
-}`,
+	instance_platform = Linux/UNIX
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_capacity_reservation" "foo" {
+	instance_platform = Linux/GNU
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2CapacityReservationInvalidInstancePlatformRule(),
-					Message: `"Linux/GNU" is an invalid value as instance_platform`,
+					Message: `Linux/GNU is an invalid value as instance_platform`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_capacity_reservation" "foo" {
-	instance_platform = "Linux/UNIX"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_capacity_reservation_invalid_tenancy_test.go
+++ b/rules/models/aws_ec2_capacity_reservation_invalid_tenancy_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2CapacityReservationInvalidTenancyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_capacity_reservation" "foo" {
-	tenancy = "reserved"
-}`,
+	tenancy = default
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_capacity_reservation" "foo" {
+	tenancy = reserved
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2CapacityReservationInvalidTenancyRule(),
-					Message: `"reserved" is an invalid value as tenancy`,
+					Message: `reserved is an invalid value as tenancy`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_capacity_reservation" "foo" {
-	tenancy = "default"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_client_vpn_endpoint_invalid_transport_protocol_test.go
+++ b/rules/models/aws_ec2_client_vpn_endpoint_invalid_transport_protocol_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2ClientVpnEndpointInvalidTransportProtocolRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_client_vpn_endpoint" "foo" {
-	transport_protocol = "http"
-}`,
+	transport_protocol = udp
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_client_vpn_endpoint" "foo" {
+	transport_protocol = http
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2ClientVpnEndpointInvalidTransportProtocolRule(),
-					Message: `"http" is an invalid value as transport_protocol`,
+					Message: `http is an invalid value as transport_protocol`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_client_vpn_endpoint" "foo" {
-	transport_protocol = "udp"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_fleet_invalid_excess_capacity_termination_policy_test.go
+++ b/rules/models/aws_ec2_fleet_invalid_excess_capacity_termination_policy_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2FleetInvalidExcessCapacityTerminationPolicyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_fleet" "foo" {
-	excess_capacity_termination_policy = "remain"
-}`,
+	excess_capacity_termination_policy = termination
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_fleet" "foo" {
+	excess_capacity_termination_policy = remain
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2FleetInvalidExcessCapacityTerminationPolicyRule(),
-					Message: `"remain" is an invalid value as excess_capacity_termination_policy`,
+					Message: `remain is an invalid value as excess_capacity_termination_policy`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_fleet" "foo" {
-	excess_capacity_termination_policy = "termination"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_fleet_invalid_type_test.go
+++ b/rules/models/aws_ec2_fleet_invalid_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2FleetInvalidTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_fleet" "foo" {
-	type = "remain"
-}`,
+	type = maintain
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_fleet" "foo" {
+	type = remain
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2FleetInvalidTypeRule(),
-					Message: `"remain" is an invalid value as type`,
+					Message: `remain is an invalid value as type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_fleet" "foo" {
-	type = "maintain"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_transit_gateway_invalid_auto_accept_shared_attachments_test.go
+++ b/rules/models/aws_ec2_transit_gateway_invalid_auto_accept_shared_attachments_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2TransitGatewayInvalidAutoAcceptSharedAttachmentsRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_transit_gateway" "foo" {
-	auto_accept_shared_attachments = "true"
-}`,
+	auto_accept_shared_attachments = enable
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_transit_gateway" "foo" {
+	auto_accept_shared_attachments = true
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2TransitGatewayInvalidAutoAcceptSharedAttachmentsRule(),
-					Message: `"true" is an invalid value as auto_accept_shared_attachments`,
+					Message: `true is an invalid value as auto_accept_shared_attachments`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_transit_gateway" "foo" {
-	auto_accept_shared_attachments = "enable"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_transit_gateway_invalid_default_route_table_association_test.go
+++ b/rules/models/aws_ec2_transit_gateway_invalid_default_route_table_association_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2TransitGatewayInvalidDefaultRouteTableAssociationRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_transit_gateway" "foo" {
-	default_route_table_association = "false"
-}`,
+	default_route_table_association = disable
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_transit_gateway" "foo" {
+	default_route_table_association = false
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2TransitGatewayInvalidDefaultRouteTableAssociationRule(),
-					Message: `"false" is an invalid value as default_route_table_association`,
+					Message: `false is an invalid value as default_route_table_association`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_transit_gateway" "foo" {
-	default_route_table_association = "disable"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_transit_gateway_invalid_default_route_table_propagation_test.go
+++ b/rules/models/aws_ec2_transit_gateway_invalid_default_route_table_propagation_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2TransitGatewayInvalidDefaultRouteTablePropagationRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_transit_gateway" "foo" {
-	default_route_table_propagation = "disabled"
-}`,
+	default_route_table_propagation = disable
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_transit_gateway" "foo" {
+	default_route_table_propagation = disabled
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2TransitGatewayInvalidDefaultRouteTablePropagationRule(),
-					Message: `"disabled" is an invalid value as default_route_table_propagation`,
+					Message: `disabled is an invalid value as default_route_table_propagation`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_transit_gateway" "foo" {
-	default_route_table_propagation = "disable"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_transit_gateway_invalid_dns_support_test.go
+++ b/rules/models/aws_ec2_transit_gateway_invalid_dns_support_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2TransitGatewayInvalidDNSSupportRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_transit_gateway" "foo" {
-	dns_support = "enabled"
-}`,
+	dns_support = enable
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_transit_gateway" "foo" {
+	dns_support = enabled
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2TransitGatewayInvalidDNSSupportRule(),
-					Message: `"enabled" is an invalid value as dns_support`,
+					Message: `enabled is an invalid value as dns_support`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_transit_gateway" "foo" {
-	dns_support = "enable"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ec2_transit_gateway_vpc_attachment_invalid_ipv6_support_test.go
+++ b/rules/models/aws_ec2_transit_gateway_vpc_attachment_invalid_ipv6_support_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEc2TransitGatewayVpcAttachmentInvalidIpv6SupportRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ec2_transit_gateway_vpc_attachment" "foo" {
-	ipv6_support = "on"
-}`,
+	ipv6_support = enable
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ec2_transit_gateway_vpc_attachment" "foo" {
+	ipv6_support = on
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEc2TransitGatewayVpcAttachmentInvalidIpv6SupportRule(),
-					Message: `"on" is an invalid value as ipv6_support`,
+					Message: `on is an invalid value as ipv6_support`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ec2_transit_gateway_vpc_attachment" "foo" {
-	ipv6_support = "enable"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ecr_lifecycle_policy_invalid_repository_test.go
+++ b/rules/models/aws_ecr_lifecycle_policy_invalid_repository_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEcrLifecyclePolicyInvalidRepositoryRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ecr_lifecycle_policy" "foo" {
-	repository = "example@com"
-}`,
+	repository = example
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ecr_lifecycle_policy" "foo" {
+	repository = example@com
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEcrLifecyclePolicyInvalidRepositoryRule(),
-					Message: `"example@com" does not match valid pattern ^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$`,
+					Message: `example@com does not match valid pattern ^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ecr_lifecycle_policy" "foo" {
-	repository = "example"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ecs_service_invalid_launch_type_test.go
+++ b/rules/models/aws_ecs_service_invalid_launch_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEcsServiceInvalidLaunchTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ecs_service" "foo" {
-	launch_type = "POD"
-}`,
+	launch_type = FARGATE
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ecs_service" "foo" {
+	launch_type = POD
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEcsServiceInvalidLaunchTypeRule(),
-					Message: `"POD" is an invalid value as launch_type`,
+					Message: `POD is an invalid value as launch_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ecs_service" "foo" {
-	launch_type = "FARGATE"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ecs_service_invalid_propagate_tags_test.go
+++ b/rules/models/aws_ecs_service_invalid_propagate_tags_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEcsServiceInvalidPropagateTagsRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ecs_service" "foo" {
-	propagate_tags = "CONTAINER"
-}`,
+	propagate_tags = SERVICE
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ecs_service" "foo" {
+	propagate_tags = CONTAINER
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEcsServiceInvalidPropagateTagsRule(),
-					Message: `"CONTAINER" is an invalid value as propagate_tags`,
+					Message: `CONTAINER is an invalid value as propagate_tags`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ecs_service" "foo" {
-	propagate_tags = "SERVICE"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ecs_service_invalid_scheduling_strategy_test.go
+++ b/rules/models/aws_ecs_service_invalid_scheduling_strategy_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEcsServiceInvalidSchedulingStrategyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ecs_service" "foo" {
-	scheduling_strategy = "SERVER"
-}`,
+	scheduling_strategy = REPLICA
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ecs_service" "foo" {
+	scheduling_strategy = SERVER
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEcsServiceInvalidSchedulingStrategyRule(),
-					Message: `"SERVER" is an invalid value as scheduling_strategy`,
+					Message: `SERVER is an invalid value as scheduling_strategy`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ecs_service" "foo" {
-	scheduling_strategy = "REPLICA"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ecs_task_definition_invalid_ipc_mode_test.go
+++ b/rules/models/aws_ecs_task_definition_invalid_ipc_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEcsTaskDefinitionInvalidIpcModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ecs_task_definition" "foo" {
-	ipc_mode = "vpc"
-}`,
+	ipc_mode = host
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ecs_task_definition" "foo" {
+	ipc_mode = vpc
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEcsTaskDefinitionInvalidIpcModeRule(),
-					Message: `"vpc" is an invalid value as ipc_mode`,
+					Message: `vpc is an invalid value as ipc_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ecs_task_definition" "foo" {
-	ipc_mode = "host"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ecs_task_definition_invalid_network_mode_test.go
+++ b/rules/models/aws_ecs_task_definition_invalid_network_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEcsTaskDefinitionInvalidNetworkModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ecs_task_definition" "foo" {
-	network_mode = "vpc"
-}`,
+	network_mode = bridge
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ecs_task_definition" "foo" {
+	network_mode = vpc
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEcsTaskDefinitionInvalidNetworkModeRule(),
-					Message: `"vpc" is an invalid value as network_mode`,
+					Message: `vpc is an invalid value as network_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ecs_task_definition" "foo" {
-	network_mode = "bridge"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_ecs_task_definition_invalid_pid_mode_test.go
+++ b/rules/models/aws_ecs_task_definition_invalid_pid_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEcsTaskDefinitionInvalidPidModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_ecs_task_definition" "foo" {
-	pid_mode = "awsvpc"
-}`,
+	pid_mode = task
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_ecs_task_definition" "foo" {
+	pid_mode = awsvpc
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEcsTaskDefinitionInvalidPidModeRule(),
-					Message: `"awsvpc" is an invalid value as pid_mode`,
+					Message: `awsvpc is an invalid value as pid_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_ecs_task_definition" "foo" {
-	pid_mode = "task"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_efs_file_system_invalid_performance_mode_test.go
+++ b/rules/models/aws_efs_file_system_invalid_performance_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEfsFileSystemInvalidPerformanceModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_efs_file_system" "foo" {
-	performance_mode = "minIO"
-}`,
+	performance_mode = generalPurpose
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_efs_file_system" "foo" {
+	performance_mode = minIO
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEfsFileSystemInvalidPerformanceModeRule(),
-					Message: `"minIO" is an invalid value as performance_mode`,
+					Message: `minIO is an invalid value as performance_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_efs_file_system" "foo" {
-	performance_mode = "generalPurpose"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_efs_file_system_invalid_throughput_mode_test.go
+++ b/rules/models/aws_efs_file_system_invalid_throughput_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEfsFileSystemInvalidThroughputModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_efs_file_system" "foo" {
-	throughput_mode = "generalPurpose"
-}`,
+	throughput_mode = bursting
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_efs_file_system" "foo" {
+	throughput_mode = generalPurpose
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEfsFileSystemInvalidThroughputModeRule(),
-					Message: `"generalPurpose" is an invalid value as throughput_mode`,
+					Message: `generalPurpose is an invalid value as throughput_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_efs_file_system" "foo" {
-	throughput_mode = "bursting"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_eks_cluster_invalid_name_test.go
+++ b/rules/models/aws_eks_cluster_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsEksClusterInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_eks_cluster" "foo" {
-	name = "@example"
-}`,
+	name = example
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_eks_cluster" "foo" {
+	name = @example
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsEksClusterInvalidNameRule(),
-					Message: `"@example" does not match valid pattern ^[0-9A-Za-z][A-Za-z0-9\-_]*`,
+					Message: `@example does not match valid pattern ^[0-9A-Za-z][A-Za-z0-9\-_]*`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_eks_cluster" "foo" {
-	name = "example"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_elasticache_cluster_invalid_az_mode_test.go
+++ b/rules/models/aws_elasticache_cluster_invalid_az_mode_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsElastiCacheClusterInvalidAzModeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_elasticache_cluster" "foo" {
-	az_mode = "multi-az"
-}`,
+	az_mode = cross-az
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_elasticache_cluster" "foo" {
+	az_mode = multi-az
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsElastiCacheClusterInvalidAzModeRule(),
-					Message: `"multi-az" is an invalid value as az_mode`,
+					Message: `multi-az is an invalid value as az_mode`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_elasticache_cluster" "foo" {
-	az_mode = "cross-az"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_elastictranscoder_preset_invalid_container_test.go
+++ b/rules/models/aws_elastictranscoder_preset_invalid_container_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsElastictranscoderPresetInvalidContainerRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_elastictranscoder_preset" "foo" {
-	container = "mp1"
-}`,
+	container = mp4
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_elastictranscoder_preset" "foo" {
+	container = mp1
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsElastictranscoderPresetInvalidContainerRule(),
-					Message: `"mp1" does not match valid pattern ^(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^flac$)|(^oga$)|(^ogg$)|(^fmp4$)|(^mpg$)|(^flv$)|(^gif$)|(^mxf$)|(^wav$)|(^mp2$)$`,
+					Message: `mp1 does not match valid pattern ^(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^flac$)|(^oga$)|(^ogg$)|(^fmp4$)|(^mpg$)|(^flv$)|(^gif$)|(^mxf$)|(^wav$)|(^mp2$)$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_elastictranscoder_preset" "foo" {
-	container = "mp4"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_instance_invalid_instance_initiated_shutdown_behavior_test.go
+++ b/rules/models/aws_instance_invalid_instance_initiated_shutdown_behavior_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsInstanceInvalidInstanceInitiatedShutdownBehaviorRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_instance" "foo" {
-	instance_initiated_shutdown_behavior = "restart"
-}`,
+	instance_initiated_shutdown_behavior = stop
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_instance" "foo" {
+	instance_initiated_shutdown_behavior = restart
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsInstanceInvalidInstanceInitiatedShutdownBehaviorRule(),
-					Message: `"restart" is an invalid value as instance_initiated_shutdown_behavior`,
+					Message: `restart is an invalid value as instance_initiated_shutdown_behavior`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_instance" "foo" {
-	instance_initiated_shutdown_behavior = "stop"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_instance_invalid_tenancy_test.go
+++ b/rules/models/aws_instance_invalid_tenancy_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsInstanceInvalidTenancyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_instance" "foo" {
-	tenancy = "server"
-}`,
+	tenancy = host
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_instance" "foo" {
+	tenancy = server
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsInstanceInvalidTenancyRule(),
-					Message: `"server" is an invalid value as tenancy`,
+					Message: `server is an invalid value as tenancy`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_instance" "foo" {
-	tenancy = "host"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_launch_template_invalid_instance_type_test.go
+++ b/rules/models/aws_launch_template_invalid_instance_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsLaunchTemplateInvalidInstanceTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_launch_template" "foo" {
-	instance_type = "t1.2xlarge"
-}`,
+	instance_type = t2.micro
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_launch_template" "foo" {
+	instance_type = t1.2xlarge
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsLaunchTemplateInvalidInstanceTypeRule(),
-					Message: `"t1.2xlarge" is an invalid value as instance_type`,
+					Message: `t1.2xlarge is an invalid value as instance_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_launch_template" "foo" {
-	instance_type = "t2.micro"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_launch_template_invalid_name_test.go
+++ b/rules/models/aws_launch_template_invalid_name_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsLaunchTemplateInvalidNameRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_launch_template" "foo" {
-	name = "foo[bar]"
-}`,
+	name = foo
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_launch_template" "foo" {
+	name = foo[bar]
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsLaunchTemplateInvalidNameRule(),
-					Message: `"foo[bar]" does not match valid pattern ^[a-zA-Z0-9\(\)\.\-/_]+$`,
+					Message: `foo[bar] does not match valid pattern ^[a-zA-Z0-9\(\)\.\-/_]+$`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_launch_template" "foo" {
-	name = "foo"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_lb_invalid_ip_address_type_test.go
+++ b/rules/models/aws_lb_invalid_ip_address_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsLbInvalidIPAddressTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_lb" "foo" {
-	ip_address_type = "ipv6"
-}`,
+	ip_address_type = ipv4
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_lb" "foo" {
+	ip_address_type = ipv6
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsLbInvalidIPAddressTypeRule(),
-					Message: `"ipv6" is an invalid value as ip_address_type`,
+					Message: `ipv6 is an invalid value as ip_address_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_lb" "foo" {
-	ip_address_type = "ipv4"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_lb_invalid_load_balancer_type_test.go
+++ b/rules/models/aws_lb_invalid_load_balancer_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsLbInvalidLoadBalancerTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_lb" "foo" {
-	load_balancer_type = "classic"
-}`,
+	load_balancer_type = application
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_lb" "foo" {
+	load_balancer_type = classic
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsLbInvalidLoadBalancerTypeRule(),
-					Message: `"classic" is an invalid value as load_balancer_type`,
+					Message: `classic is an invalid value as load_balancer_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_lb" "foo" {
-	load_balancer_type = "application"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_lb_listener_invalid_protocol_test.go
+++ b/rules/models/aws_lb_listener_invalid_protocol_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsLbListenerInvalidProtocolRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_lb_listener" "foo" {
-	protocol = "INVALID"
-}`,
+	protocol = HTTPS
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_lb_listener" "foo" {
+	protocol = INVALID
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsLbListenerInvalidProtocolRule(),
-					Message: `"INVALID" is an invalid value as protocol`,
+					Message: `INVALID is an invalid value as protocol`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_lb_listener" "foo" {
-	protocol = "HTTPS"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_lb_target_group_invalid_target_type_test.go
+++ b/rules/models/aws_lb_target_group_invalid_target_type_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsLbTargetGroupInvalidTargetTypeRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_lb_target_group" "foo" {
-	target_type = "container"
-}`,
+	target_type = lambda
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_lb_target_group" "foo" {
+	target_type = container
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsLbTargetGroupInvalidTargetTypeRule(),
-					Message: `"container" is an invalid value as target_type`,
+					Message: `container is an invalid value as target_type`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_lb_target_group" "foo" {
-	target_type = "lambda"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_placement_group_invalid_strategy_test.go
+++ b/rules/models/aws_placement_group_invalid_strategy_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsPlacementGroupInvalidStrategyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_placement_group" "foo" {
-	strategy = "instance"
-}`,
+	strategy = cluster
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_placement_group" "foo" {
+	strategy = instance
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsPlacementGroupInvalidStrategyRule(),
-					Message: `"instance" is an invalid value as strategy`,
+					Message: `instance is an invalid value as strategy`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_placement_group" "foo" {
-	strategy = "cluster"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_spot_fleet_request_invalid_allocation_strategy_test.go
+++ b/rules/models/aws_spot_fleet_request_invalid_allocation_strategy_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsSpotFleetRequestInvalidAllocationStrategyRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_spot_fleet_request" "foo" {
-	allocation_strategy = "highestPrice"
-}`,
+	allocation_strategy = lowestPrice
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_spot_fleet_request" "foo" {
+	allocation_strategy = highestPrice
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsSpotFleetRequestInvalidAllocationStrategyRule(),
-					Message: `"highestPrice" is an invalid value as allocation_strategy`,
+					Message: `highestPrice is an invalid value as allocation_strategy`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_spot_fleet_request" "foo" {
-	allocation_strategy = "lowestPrice"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/aws_spot_fleet_request_invalid_instance_interruption_behaviour_test.go
+++ b/rules/models/aws_spot_fleet_request_invalid_instance_interruption_behaviour_test.go
@@ -10,30 +10,27 @@ import (
 
 func Test_AwsSpotFleetRequestInvalidInstanceInterruptionBehaviourRule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
 			Content: `
 resource "aws_spot_fleet_request" "foo" {
-	instance_interruption_behaviour = "restart"
-}`,
+	instance_interruption_behaviour = hibernate
+	}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Content: `
+resource "aws_spot_fleet_request" "foo" {
+	instance_interruption_behaviour = restart
+	}`,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsSpotFleetRequestInvalidInstanceInterruptionBehaviourRule(),
-					Message: `"restart" is an invalid value as instance_interruption_behaviour`,
+					Message: `restart is an invalid value as instance_interruption_behaviour`,
 				},
 			},
-		},
-		{
-			Name: "It is valid",
-			Content: `
-resource "aws_spot_fleet_request" "foo" {
-	instance_interruption_behaviour = "hibernate"
-}`,
-			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/models/generator/main.go
+++ b/rules/models/generator/main.go
@@ -1,3 +1,4 @@
+//go:build generators
 // +build generators
 
 package main
@@ -27,10 +28,10 @@ type mapping struct {
 }
 
 type test struct {
-	Resource  string `hcl:"resource,label"`
-	Attribute string `hcl:"attribute,label"`
-	OK        string `hcl:"ok"`
-	NG        string `hcl:"ng"`
+	Resource  string   `hcl:"resource,label"`
+	Attribute string   `hcl:"attribute,label"`
+	Valid     []string `hcl:"valid"`
+	Invalid   []string `hcl:"invalid"`
 }
 
 func main() {

--- a/rules/models/generator/rule.go
+++ b/rules/models/generator/rule.go
@@ -1,3 +1,4 @@
+//go:build generators
 // +build generators
 
 package main
@@ -20,8 +21,9 @@ type ruleMeta struct {
 	Min           int
 	Pattern       string
 	Enum          []string
-	TestOK        string
-	TestNG        string
+
+	Valid   []string
+	Invalid []string
 }
 
 func generateRuleFile(resource, attribute string, model map[string]interface{}, schema utils.AttributeSchema) {
@@ -57,8 +59,8 @@ func generateRuleTestFile(resource, attribute string, model map[string]interface
 		Min:           fetchNumber(model, "min"),
 		Pattern:       replacePattern(fetchString(model, "pattern")),
 		Enum:          fetchStrings(model, "enum"),
-		TestOK:        formatTest(test.OK),
-		TestNG:        formatTest(test.NG),
+		Valid:         test.Valid,
+		Invalid:       test.Invalid,
 	}
 
 	// Testing generated regexp

--- a/rules/models/mappings/acm-pca.hcl
+++ b/rules/models/mappings/acm-pca.hcl
@@ -17,6 +17,6 @@ mapping "aws_acmpca_certificate_authority_certificate" {
 }
 
 test "aws_acmpca_certificate_authority" "type" {
-  ok = "SUBORDINATE"
-  ng = "ORDINATE"
+  valid   = ["SUBORDINATE"]
+  invalid = ["ORDINATE"]
 }

--- a/rules/models/mappings/apigateway.hcl
+++ b/rules/models/mappings/apigateway.hcl
@@ -45,41 +45,41 @@ mapping "aws_api_gateway_stage" {
 }
 
 test "aws_api_gateway_gateway_response" "status_code" {
-  ok = "200"
-  ng = "004"
+  valid   = ["200"]
+  invalid = ["004"]
 }
 
 test "aws_api_gateway_authorizer" "type" {
-  ok = "TOKEN"
-  ng = "RESPONSE"
+  valid   = ["TOKEN"]
+  invalid = ["RESPONSE"]
 }
 
 test "aws_api_gateway_gateway_response" "response_type" {
-  ok = "UNAUTHORIZED"
-  ng = "4XX"
+  valid   = ["UNAUTHORIZED"]
+  invalid = ["4XX"]
 }
 
 test "aws_api_gateway_integration" "type" {
-  ok = "HTTP"
-  ng = "AWS_HTTP"
+  valid   = ["HTTP"]
+  invalid = ["AWS_HTTP"]
 }
 
 test "aws_api_gateway_integration" "connection_type" {
-  ok = "INTERNET"
-  ng = "INTRANET"
+  valid   = ["INTERNET"]
+  invalid = ["INTRANET"]
 }
 
 test "aws_api_gateway_integration" "content_handling" {
-  ok = "CONVERT_TO_BINARY"
-  ng = "CONVERT_TO_FILE"
+  valid   = ["CONVERT_TO_BINARY"]
+  invalid = ["CONVERT_TO_FILE"]
 }
 
 test "aws_api_gateway_rest_api" "api_key_source" {
-  ok = "AUTHORIZER"
-  ng = "BODY"
+  valid   = ["AUTHORIZER"]
+  invalid = ["BODY"]
 }
 
 test "aws_api_gateway_stage" "cache_cluster_size" {
-  ok = "6.1"
-  ng = "6.2"
+  valid   = ["6.1"]
+  invalid = ["6.2"]
 }

--- a/rules/models/mappings/application-autoscaling.hcl
+++ b/rules/models/mappings/application-autoscaling.hcl
@@ -17,16 +17,16 @@ mapping "aws_appautoscaling_target" {
 }
 
 test "aws_appautoscaling_policy" "policy_type" {
-  ok = "StepScaling"
-  ng = "StopScaling"
+  valid   = ["StepScaling"]
+  invalid = ["StopScaling"]
 }
 
 test "aws_appautoscaling_policy" "scalable_dimension" {
-  ok = "ecs:service:DesiredCount"
-  ng = "ecs:service:DesireCount"
+  valid   = ["ecs:service:DesiredCount"]
+  invalid = ["ecs:service:DesireCount"]
 }
 
 test "aws_appautoscaling_policy" "service_namespace" {
-  ok = "ecs"
-  ng = "eks"
+  valid   = ["ecs"]
+  invalid = ["eks"]
 }

--- a/rules/models/mappings/appsync.hcl
+++ b/rules/models/mappings/appsync.hcl
@@ -28,16 +28,16 @@ mapping "aws_appsync_function" {
 }
 
 test "aws_appsync_datasource" "name" {
-  ok = "tf_appsync_example"
-  ng = "01_tf_example"
+  valid   = ["tf_appsync_example"]
+  invalid = ["01_tf_example"]
 }
 
 test "aws_appsync_datasource" "type" {
-  ok = "AWS_LAMBDA"
-  ng = "AMAZON_SIMPLEDB"
+  valid   = ["AWS_LAMBDA"]
+  invalid = ["AMAZON_SIMPLEDB"]
 }
 
 test "aws_appsync_graphql_api" "authentication_type" {
-  ok = "API_KEY"
-  ng = "AWS_KEY"
+  valid   = ["API_KEY"]
+  invalid = ["AWS_KEY"]
 }

--- a/rules/models/mappings/backup.hcl
+++ b/rules/models/mappings/backup.hcl
@@ -23,11 +23,11 @@ mapping "aws_backup_vault_policy" {
 }
 
 test "aws_backup_selection" "name" {
-  ok = "tf_example_backup_selection"
-  ng = "tf_example_backup_selection_tf_example_backup_selection"
+  valid   = ["tf_example_backup_selection"]
+  invalid = ["tf_example_backup_selection_tf_example_backup_selection"]
 }
 
 test "aws_backup_vault" "name" {
-  ok = "example_backup_vault"
-  ng = "example_backup_vault_example_backup_vault_example_backup_vault"
+  valid   = ["example_backup_vault"]
+  invalid = ["example_backup_vault_example_backup_vault_example_backup_vault"]
 }

--- a/rules/models/mappings/batch.hcl
+++ b/rules/models/mappings/batch.hcl
@@ -14,21 +14,21 @@ mapping "aws_batch_job_queue" {
 }
 
 test "aws_batch_compute_environment" "state" {
-  ok = "ENABLED"
-  ng = "ON"
+  valid   = ["ENABLED"]
+  invalid = ["ON"]
 }
 
 test "aws_batch_compute_environment" "type" {
-  ok = "MANAGED"
-  ng = "CONTROLLED"
+  valid   = ["MANAGED"]
+  invalid = ["CONTROLLED"]
 }
 
 test "aws_batch_job_definition" "type" {
-  ok = "container"
-  ng = "docker"
+  valid   = ["container"]
+  invalid = ["docker"]
 }
 
 test "aws_batch_job_queue" "state" {
-  ok = "ENABLED"
-  ng = "ON"
+  valid   = ["ENABLED"]
+  invalid = ["ON"]
 }

--- a/rules/models/mappings/budgets.hcl
+++ b/rules/models/mappings/budgets.hcl
@@ -8,21 +8,21 @@ mapping "aws_budgets_budget" {
 }
 
 test "aws_budgets_budget" "account_id" {
-  ok = "123456789012"
-  ng = "abcdefghijkl"
+  valid   = ["123456789012"]
+  invalid = ["abcdefghijkl"]
 }
 
 test "aws_budgets_budget" "name" {
-  ok = "budget-ec2-monthly"
-  ng = "budget:ec2:monthly"
+  valid   = ["budget-ec2-monthly"]
+  invalid = ["budget:ec2:monthly"]
 }
 
 test "aws_budgets_budget" "budget_type" {
-  ok = "USAGE"
-  ng = "MONEY"
+  valid   = ["USAGE"]
+  invalid = ["MONEY"]
 }
 
 test "aws_budgets_budget" "time_unit" {
-  ok = "MONTHLY"
-  ng = "HOURLY"
+  valid   = ["MONTHLY"]
+  invalid = ["HOURLY"]
 }

--- a/rules/models/mappings/cloud9.hcl
+++ b/rules/models/mappings/cloud9.hcl
@@ -10,11 +10,11 @@ mapping "aws_cloud9_environment_ec2" {
 }
 
 test "aws_cloud9_environment_ec2" "instance_type" {
-  ok = "t2.micro"
-  ng = "t20.micro"
+  valid   = ["t2.micro"]
+  invalid = ["t20.micro"]
 }
 
 test "aws_cloud9_environment_ec2" "owner_arn" {
-  ok = "arn:aws:iam::123456789012:user/David"
-  ng = "arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment"
+  valid   = ["arn:aws:iam::123456789012:user/David"]
+  invalid = ["arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment"]
 }

--- a/rules/models/mappings/cloudformation.hcl
+++ b/rules/models/mappings/cloudformation.hcl
@@ -22,16 +22,16 @@ mapping "aws_cloudformation_stack_set_instance" {
 }
 
 test "aws_cloudformation_stack" "on_failure" {
-  ok = "DO_NOTHING"
-  ng = "DO_ANYTHING"
+  valid   = ["DO_NOTHING"]
+  invalid = ["DO_ANYTHING"]
 }
 
 test "aws_cloudformation_stack_set" "execution_role_name" {
-  ok = "AWSCloudFormationStackSetExecutionRole"
-  ng = "AWSCloudFormation/StackSet/ExecutionRole"
+  valid   = ["AWSCloudFormationStackSetExecutionRole"]
+  invalid = ["AWSCloudFormation/StackSet/ExecutionRole"]
 }
 
 test "aws_cloudformation_stack_set_instance" "account_id" {
-  ok = "123456789012"
-  ng = "1234567890123"
+  valid   = ["123456789012"]
+  invalid = ["1234567890123"]
 }

--- a/rules/models/mappings/cloudfront.hcl
+++ b/rules/models/mappings/cloudfront.hcl
@@ -42,11 +42,11 @@ mapping "aws_cloudfront_response_headers_policy" {
 }
 
 test "aws_cloudfront_distribution" "http_version" {
-  ok = "http2"
-  ng = "http1.2"
+  valid   = ["http2"]
+  invalid = ["http1.2"]
 }
 
 test "aws_cloudfront_distribution" "price_class" {
-  ok = "PriceClass_All"
-  ng = "PriceClass_300"
+  valid   = ["PriceClass_All"]
+  invalid = ["PriceClass_300"]
 }

--- a/rules/models/mappings/cloudhsmv2.hcl
+++ b/rules/models/mappings/cloudhsmv2.hcl
@@ -13,31 +13,31 @@ mapping "aws_cloudhsm_v2_hsm" {
 }
 
 test "aws_cloudhsm_v2_cluster" "source_backup_identifier" {
-  ok = "backup-rtq2dwi2gq6"
-  ng = "rtq2dwi2gq6"
+  valid   = ["backup-rtq2dwi2gq6"]
+  invalid = ["rtq2dwi2gq6"]
 }
 
 test "aws_cloudhsm_v2_cluster" "hsm_type" {
-  ok = "hsm1.medium"
-  ng = "hsm1.micro"
+  valid   = ["hsm1.medium"]
+  invalid = ["hsm1.micro"]
 }
 
 test "aws_cloudhsm_v2_hsm" "cluster_id" {
-  ok = "cluster-jxhlf7644ne"
-  ng = "jxhlf7644ne"
+  valid   = ["cluster-jxhlf7644ne"]
+  invalid = ["jxhlf7644ne"]
 }
 
 test "aws_cloudhsm_v2_hsm" "subnet_id" {
-  ok = "subnet-0e358c43"
-  ng = "0e358c43"
+  valid   = ["subnet-0e358c43"]
+  invalid = ["0e358c43"]
 }
 
 test "aws_cloudhsm_v2_hsm" "availability_zone" {
-  ok = "us-east-1a"
-  ng = "us-east-1"
+  valid   = ["us-east-1a"]
+  invalid = ["us-east-1"]
 }
 
 test "aws_cloudhsm_v2_hsm" "ip_address" {
-  ok = "8.8.8.8"
-  ng = "2001:4860:4860::8888"
+  valid   = ["8.8.8.8"]
+  invalid = ["2001:4860:4860::8888"]
 }

--- a/rules/models/mappings/cloudwatch-event.hcl
+++ b/rules/models/mappings/cloudwatch-event.hcl
@@ -57,26 +57,26 @@ mapping "aws_cloudwatch_event_target" {
 }
 
 test "aws_cloudwatch_event_permission" "principal" {
-  ok = "*"
-  ng = "-"
+  valid   = ["*"]
+  invalid = ["-"]
 }
 
 test "aws_cloudwatch_event_permission" "statement_id" {
-  ok = "OrganizationAccess"
-  ng = "Organization Access"
+  valid   = ["OrganizationAccess"]
+  invalid = ["Organization Access"]
 }
 
 test "aws_cloudwatch_event_permission" "action" {
-  ok = "events:PutEvents"
-  ng = "cloudwatchevents:PutEvents"
+  valid   = ["events:PutEvents"]
+  invalid = ["cloudwatchevents:PutEvents"]
 }
 
 test "aws_cloudwatch_event_rule" "name" {
-  ok = "capture-aws-sign-in"
-  ng = "capture aws sign in"
+  valid   = ["capture-aws-sign-in"]
+  invalid = ["capture aws sign in"]
 }
 
 test "aws_cloudwatch_event_target" "target_id" {
-  ok = "run-scheduled-task-every-hour"
-  ng = "run scheduled task every hour"
+  valid   = ["run-scheduled-task-every-hour"]
+  invalid = ["run scheduled task every hour"]
 }

--- a/rules/models/mappings/cloudwatch-log.hcl
+++ b/rules/models/mappings/cloudwatch-log.hcl
@@ -36,31 +36,31 @@ mapping "aws_cloudwatch_log_subscription_filter" {
 }
 
 test "aws_cloudwatch_log_destination" "name" {
-  ok = "test_destination"
-  ng = "test:destination"
+  valid   = ["test_destination"]
+  invalid = ["test:destination"]
 }
 
 test "aws_cloudwatch_log_group" "name" {
-  ok = "Yada"
-  ng = "Yoda:prod"
+  valid   = ["Yada"]
+  invalid = ["Yoda:prod"]
 }
 
 test "aws_cloudwatch_log_metric_filter" "name" {
-  ok = "MyAppAccessCount"
-  ng = "MyAppAccessCount:prod"
+  valid   = ["MyAppAccessCount"]
+  invalid = ["MyAppAccessCount:prod"]
 }
 
 test "aws_cloudwatch_log_stream" "name" {
-  ok = "Yada"
-  ng = "Yoda:prod"
+  valid   = ["Yada"]
+  invalid = ["Yoda:prod"]
 }
 
 test "aws_cloudwatch_log_subscription_filter" "name" {
-  ok = "test_lambdafunction_logfilter"
-  ng = "test_lambdafunction_logfilter:test"
+  valid   = ["test_lambdafunction_logfilter"]
+  invalid = ["test_lambdafunction_logfilter:test"]
 }
 
 test "aws_cloudwatch_log_subscription_filter" "distribution" {
-  ok = "Random"
-  ng = "LogStream"
+  valid   = ["Random"]
+  invalid = ["LogStream"]
 }

--- a/rules/models/mappings/cloudwatch-metric.hcl
+++ b/rules/models/mappings/cloudwatch-metric.hcl
@@ -14,26 +14,26 @@ mapping "aws_cloudwatch_metric_alarm" {
 }
 
 test "aws_cloudwatch_metric_alarm" "comparison_operator" {
-  ok = "GreaterThanOrEqualToThreshold"
-  ng = "GreaterThanOrEqual"
+  valid   = ["GreaterThanOrEqualToThreshold"]
+  invalid = ["GreaterThanOrEqual"]
 }
 
 test "aws_cloudwatch_metric_alarm" "namespace" {
-  ok = "AWS/EC2"
-  ng = ":EC2"
+  valid   = ["AWS/EC2"]
+  invalid = [":EC2"]
 }
 
 test "aws_cloudwatch_metric_alarm" "statistic" {
-  ok = "Average"
-  ng = "Median"
+  valid   = ["Average"]
+  invalid = ["Median"]
 }
 
 test "aws_cloudwatch_metric_alarm" "unit" {
-  ok = "Gigabytes"
-  ng = "GB"
+  valid   = ["Gigabytes"]
+  invalid = ["GB"]
 }
 
 test "aws_cloudwatch_metric_alarm" "extended_statistic" {
-  ok = "p100"
-  ng = "p101"
+  valid   = ["p100"]
+  invalid = ["p101"]
 }

--- a/rules/models/mappings/codecommit.hcl
+++ b/rules/models/mappings/codecommit.hcl
@@ -22,6 +22,6 @@ mapping "aws_codecommit_trigger" {
 }
 
 test "aws_codecommit_repository" "repository_name" {
-  ok = "MyTestRepository"
-  ng = "mytest@repository"
+  valid   = ["MyTestRepository"]
+  invalid = ["mytest@repository"]
 }

--- a/rules/models/mappings/codedeploy.hcl
+++ b/rules/models/mappings/codedeploy.hcl
@@ -17,6 +17,6 @@ mapping "aws_codedeploy_deployment_group" {
 }
 
 test "aws_codedeploy_app" "compute_platform" {
-  ok = "Server"
-  ng = "Fargate"
+  valid   = ["Server"]
+  invalid = ["Fargate"]
 }

--- a/rules/models/mappings/codepipeline.hcl
+++ b/rules/models/mappings/codepipeline.hcl
@@ -13,26 +13,26 @@ mapping "aws_codepipeline_webhook" {
 }
 
 test "aws_codepipeline" "name" {
-  ok = "tf-test-pipeline"
-  ng = "test/pipeline"
+  valid   = ["tf-test-pipeline"]
+  invalid = ["test/pipeline"]
 }
 
 test "aws_codepipeline" "role_arn" {
-  ok = "arn:aws:iam::123456789012:role/s3access"
-  ng = "arn:aws:iam::123456789012:instance-profile/s3access-profile"
+  valid   = ["arn:aws:iam::123456789012:role/s3access"]
+  invalid = ["arn:aws:iam::123456789012:instance-profile/s3access-profile"]
 }
 
 test "aws_codepipeline_webhook" "name" {
-  ok = "test-webhook-github-bar"
-  ng = "webhook-github-bar/testing"
+  valid   = ["test-webhook-github-bar"]
+  invalid = ["webhook-github-bar/testing"]
 }
 
 test "aws_codepipeline_webhook" "authentication" {
-  ok = "GITHUB_HMAC"
-  ng = "GITLAB_HMAC"
+  valid   = ["GITHUB_HMAC"]
+  invalid = ["GITLAB_HMAC"]
 }
 
 test "aws_codepipeline_webhook" "target_action" {
-  ok = "Source"
-  ng = "Source/Example"
+  valid   = ["Source"]
+  invalid = ["Source/Example"]
 }

--- a/rules/models/mappings/cognito-identity.hcl
+++ b/rules/models/mappings/cognito-identity.hcl
@@ -10,11 +10,11 @@ mapping "aws_cognito_identity_pool_roles_attachment" {
 }
 
 test "aws_cognito_identity_pool" "identity_pool_name" {
-  ok = "identity pool"
-  ng = "identity:pool"
+  valid   = ["identity pool"]
+  invalid = ["identity:pool"]
 }
 
 test "aws_cognito_identity_pool_roles_attachment" "identity_pool_id" {
-  ok = "us-east-1:0123456789"
-  ng = "0123456789"
+  valid   = ["us-east-1:0123456789"]
+  invalid = ["0123456789"]
 }

--- a/rules/models/mappings/cognito-idp.hcl
+++ b/rules/models/mappings/cognito-idp.hcl
@@ -51,71 +51,71 @@ mapping "aws_cognito_user_pool_ui_customization" {
 }
 
 test "aws_cognito_identity_provider" "user_pool_id" {
-  ok = "foo_bar"
-  ng = "foobar"
+  valid   = ["foo_bar"]
+  invalid = ["foobar"]
 }
 
 test "aws_cognito_identity_provider" "provider_name" {
-  ok = "Google"
-  ng = "\t"
+  valid   = ["Google"]
+  invalid = ["\t"]
 }
 
 test "aws_cognito_identity_provider" "provider_type" {
-  ok = "LoginWithAmazon"
-  ng = "Apple"
+  valid   = ["LoginWithAmazon"]
+  invalid = ["Apple"]
 }
 
 test "aws_cognito_resource_server" "identifier" {
-  ok = "https://example.com"
-  ng = "\t"
+  valid   = ["https://example.com"]
+  invalid = ["\t"]
 }
 
 test "aws_cognito_resource_server" "name" {
-  ok = "example"
-  ng = "example/server"
+  valid   = ["example"]
+  invalid = ["example/server"]
 }
 
 test "aws_cognito_user_group" "name" {
-  ok = "user-group"
-  ng = "user\tgroup"
+  valid   = ["user-group"]
+  invalid = ["user\tgroup"]
 }
 
 test "aws_cognito_user_group" "role_arn" {
-  ok = "arn:aws:iam::123456789012:role/s3access"
-  ng = "aws:iam::123456789012:instance-profile/s3access-profile"
+  valid   = ["arn:aws:iam::123456789012:role/s3access"]
+  invalid = ["aws:iam::123456789012:instance-profile/s3access-profile"]
 }
 
 test "aws_cognito_user_pool" "name" {
-  ok = "mypool"
-  ng = "my/pool"
+  valid   = ["mypool"]
+  invalid = ["my/pool"]
 }
 
 test "aws_cognito_user_pool" "email_verification_message" {
-  ok = "Verification code is {####}"
-  ng = "Verification code"
+  valid   = ["Verification code is {####}"]
+  invalid = ["Verification code"]
 }
 
 test "aws_cognito_user_pool" "mfa_configuration" {
-  ok = "ON"
-  ng = "IN"
+  valid   = ["ON"]
+  invalid = ["IN"]
 }
 
 test "aws_cognito_user_pool" "sms_authentication_message" {
-  ok = "Authentication code is {####}"
-  ng = "Authentication code"
+  valid   = ["Authentication code is {####}"]
+  invalid = ["Authentication code"]
 }
 
 test "aws_cognito_user_pool" "sms_verification_message" {
-  ok = "Verification code is {####}"
-  ng = "Verification code"
+  valid   = ["Verification code is {####}"]
+  invalid = ["Verification code"]
 }
 
 test "aws_cognito_user_pool_client" "default_redirect_uri" {
-  ok = "https://example.com/callback"
-  ng = "https://example com"
+  valid   = ["https://example.com/callback"]
+  invalid = ["https://example com"]
 }
 
 test "aws_cognito_user_pool_client" "name" {
-  ok = "client"
-  ng = "client/example"
+  valid   = ["client"]
+  invalid = ["client/example"]
 }

--- a/rules/models/mappings/config.hcl
+++ b/rules/models/mappings/config.hcl
@@ -85,16 +85,16 @@ mapping "aws_config_delivery_channel" {
 }
 
 test "aws_config_aggregate_authorization" "account_id" {
-  ok = "012345678910"
-  ng = "01234567891"
+  valid   = ["012345678910"]
+  invalid = ["01234567891"]
 }
 
 test "aws_config_configuration_aggregator" "name" {
-  ok = "example"
-  ng = "example.com"
+  valid   = ["example"]
+  invalid = ["example.com"]
 }
 
 test "aws_config_config_rule" "maximum_execution_frequency" {
-  ok = "One_Hour"
-  ng = "Hour"
+  valid   = ["One_Hour"]
+  invalid = ["Hour"]
 }

--- a/rules/models/mappings/cur.hcl
+++ b/rules/models/mappings/cur.hcl
@@ -11,26 +11,26 @@ mapping "aws_cur_report_definition" {
 }
 
 test "aws_cur_report_definition" "report_name" {
-  ok = "example-cur-report-definition"
-  ng = "example/cur-report-definition"
+  valid   = ["example-cur-report-definition"]
+  invalid = ["example/cur-report-definition"]
 }
 
 test "aws_cur_report_definition" "time_unit" {
-  ok = "HOURLY"
-  ng = "FORNIGHTLY"
+  valid   = ["HOURLY"]
+  invalid = ["FORNIGHTLY"]
 }
 
 test "aws_cur_report_definition" "format" {
-  ok = "textORcsv"
-  ng = "textORjson"
+  valid   = ["textORcsv"]
+  invalid = ["textORjson"]
 }
 
 test "aws_cur_report_definition" "compression" {
-  ok = "ZIP"
-  ng = "TAR"
+  valid   = ["ZIP"]
+  invalid = ["TAR"]
 }
 
 test "aws_cur_report_definition" "s3_region" {
-  ok = "us-east-1"
-  ng = "us-gov-east-1"
+  valid   = ["us-east-1"]
+  invalid = ["us-gov-east-1"]
 }

--- a/rules/models/mappings/datasync.hcl
+++ b/rules/models/mappings/datasync.hcl
@@ -58,46 +58,46 @@ mapping "aws_datasync_task" {
 }
 
 test "aws_datasync_agent" "name" {
-  ok = "example"
-  ng = "example^example"
+  valid   = ["example"]
+  invalid = ["example^example"]
 }
 
 test "aws_datasync_agent" "activation_key" {
-  ok = "F0EFT-7FPPR-GG7MC-3I9R3-27DOH"
-  ng = "F0EFT7FPPRGG7MC3I9R327DOH"
+  valid   = ["F0EFT-7FPPR-GG7MC-3I9R3-27DOH"]
+  invalid = ["F0EFT7FPPRGG7MC3I9R327DOH"]
 }
 
 test "aws_datasync_location_efs" "efs_file_system_arn" {
-  ok = "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-12345678"
-  ng = "arn:aws:eks:us-east-1:123456789012:cluster/my-cluster"
+  valid   = ["arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-12345678"]
+  invalid = ["arn:aws:eks:us-east-1:123456789012:cluster/my-cluster"]
 }
 
 test "aws_datasync_location_efs" "subdirectory" {
-  ok = "foo"
-  ng = "bar\t"
+  valid   = ["foo"]
+  invalid = ["bar\t"]
 }
 
 test "aws_datasync_location_nfs" "server_hostname" {
-  ok = "nfs.example.com"
-  ng = "nfs^example^com"
+  valid   = ["nfs.example.com"]
+  invalid = ["nfs^example^com"]
 }
 
 test "aws_datasync_location_nfs" "subdirectory" {
-  ok = "/exported/path"
-  ng = "/exported^path"
+  valid   = ["/exported/path"]
+  invalid = ["/exported^path"]
 }
 
 test "aws_datasync_location_s3" "s3_bucket_arn" {
-  ok = "arn:aws:s3:::my_corporate_bucket"
-  ng = "arn:aws:eks:us-east-1:123456789012:cluster/my-cluster"
+  valid   = ["arn:aws:s3:::my_corporate_bucket"]
+  invalid = ["arn:aws:eks:us-east-1:123456789012:cluster/my-cluster"]
 }
 
 test "aws_datasync_task" "cloudwatch_log_group_arn" {
-  ok = "arn:aws:logs:us-east-1:123456789012:log-group:my-log-group"
-  ng = "arn:aws:s3:::my_corporate_bucket"
+  valid   = ["arn:aws:logs:us-east-1:123456789012:log-group:my-log-group"]
+  invalid = ["arn:aws:s3:::my_corporate_bucket"]
 }
 
 test "aws_datasync_task" "source_location_arn" {
-  ok = "arn:aws:datasync:us-east-2:111222333444:location/loc-07db7abfc326c50fb"
-  ng = "arn:aws:datasync:us-east-2:111222333444:task/task-08de6e6697796f026"
+  valid   = ["arn:aws:datasync:us-east-2:111222333444:location/loc-07db7abfc326c50fb"]
+  invalid = ["arn:aws:datasync:us-east-2:111222333444:task/task-08de6e6697796f026"]
 }

--- a/rules/models/mappings/directconnect.hcl
+++ b/rules/models/mappings/directconnect.hcl
@@ -149,6 +149,6 @@ mapping "aws_dx_transit_virtual_interface" {
 }
 
 test "aws_dx_bgp_peer" "address_family" {
-  ok = "ipv4"
-  ng = "ipv2"
+  valid   = ["ipv4"]
+  invalid = ["ipv2"]
 }

--- a/rules/models/mappings/directory-service.hcl
+++ b/rules/models/mappings/directory-service.hcl
@@ -26,41 +26,41 @@ mapping "aws_directory_service_log_subscription" {
 }
 
 test "aws_directory_service_directory" "name" {
-  ok = "corp.notexample.com"
-  ng = "@example.com"
+  valid   = ["corp.notexample.com"]
+  invalid = ["@example.com"]
 }
 
 test "aws_directory_service_directory" "size" {
-  ok = "Small"
-  ng = "Micro"
+  valid   = ["Small"]
+  invalid = ["Micro"]
 }
 
 test "aws_directory_service_directory" "short_name" {
-  ok = "CORP"
-  ng = "CORP:EXAMPLE"
+  valid   = ["CORP"]
+  invalid = ["CORP:EXAMPLE"]
 }
 
 test "aws_directory_service_directory" "description" {
-  ok = "example"
-  ng = "@example"
+  valid   = ["example"]
+  invalid = ["@example"]
 }
 
 test "aws_directory_service_directory" "type" {
-  ok = "SimpleAD"
-  ng = "ActiveDirectory"
+  valid   = ["SimpleAD"]
+  invalid = ["ActiveDirectory"]
 }
 
 test "aws_directory_service_directory" "edition" {
-  ok = "Enterprise"
-  ng = "Free"
+  valid   = ["Enterprise"]
+  invalid = ["Free"]
 }
 
 test "aws_directory_service_conditional_forwarder" "directory_id" {
-  ok = "d-1234567890"
-  ng = "1234567890"
+  valid   = ["d-1234567890"]
+  invalid = ["1234567890"]
 }
 
 test "aws_directory_service_conditional_forwarder" "remote_domain_name" {
-  ok = "example.com"
-  ng = "example^com"
+  valid   = ["example.com"]
+  invalid = ["example^com"]
 }

--- a/rules/models/mappings/dlm.hcl
+++ b/rules/models/mappings/dlm.hcl
@@ -8,6 +8,6 @@ mapping "aws_dlm_lifecycle_policy" {
 }
 
 test "aws_dlm_lifecycle_policy" "state" {
-  ok = "ENABLED"
-  ng = "ERROR"
+  valid   = ["ENABLED"]
+  invalid = ["ERROR"]
 }

--- a/rules/models/mappings/dms.hcl
+++ b/rules/models/mappings/dms.hcl
@@ -68,16 +68,16 @@ mapping "aws_dms_replication_task" {
 }
 
 test "aws_dms_endpoint" "endpoint_type" {
-  ok = "source"
-  ng = "resource"
+  valid   = ["source"]
+  invalid = ["resource"]
 }
 
 test "aws_dms_endpoint" "ssl_mode" {
-  ok = "require"
-  ng = "verify-require"
+  valid   = ["require"]
+  invalid = ["verify-require"]
 }
 
 test "aws_dms_replication_task" "migration_type" {
-  ok = "full-load"
-  ng = "partial-load"
+  valid   = ["full-load"]
+  invalid = ["partial-load"]
 }

--- a/rules/models/mappings/dynamodb.hcl
+++ b/rules/models/mappings/dynamodb.hcl
@@ -39,12 +39,12 @@ mapping "aws_dynamodb_tag" {
 }
 
 test "aws_dynamodb_global_table" "name" {
-  ok = "myTable"
-  ng = "myTable@development"
+  valid   = ["myTable"]
+  invalid = ["myTable@development"]
 }
 
 test "aws_dynamodb_table" "billing_mode" {
-  ok = "PROVISIONED"
-  ng = "FLEXIBLE"
+  valid   = ["PROVISIONED"]
+  invalid = ["FLEXIBLE"]
 }
 

--- a/rules/models/mappings/ec2.hcl
+++ b/rules/models/mappings/ec2.hcl
@@ -398,106 +398,106 @@ mapping "aws_volume_attachment" {
 }
 
 test "aws_ami" "architecture" {
-  ok = "x86_64"
-  ng = "x86"
+  valid   = ["x86_64"]
+  invalid = ["x86"]
 }
 
 test "aws_ebs_volume" "type" {
-  ok = "gp2"
-  ng = "gp1"
+  valid   = ["gp2"]
+  invalid = ["gp1"]
 }
 
 test "aws_ec2_capacity_reservation" "end_date_type" {
-  ok = "unlimited"
-  ng = "unlimit"
+  valid   = ["unlimited"]
+  invalid = ["unlimit"]
 }
 
 test "aws_ec2_capacity_reservation" "instance_match_criteria" {
-  ok = "open"
-  ng = "close"
+  valid   = ["open"]
+  invalid = ["close"]
 }
 
 test "aws_ec2_capacity_reservation" "instance_platform" {
-  ok = "Linux/UNIX"
-  ng = "Linux/GNU"
+  valid   = ["Linux/UNIX"]
+  invalid = ["Linux/GNU"]
 }
 
 test "aws_ec2_capacity_reservation" "tenancy" {
-  ok = "default"
-  ng = "reserved"
+  valid   = ["default"]
+  invalid = ["reserved"]
 }
 
 test "aws_ec2_client_vpn_endpoint" "transport_protocol" {
-  ok = "udp"
-  ng = "http"
+  valid   = ["udp"]
+  invalid = ["http"]
 }
 
 test "aws_ec2_fleet" "excess_capacity_termination_policy" {
-  ok = "termination"
-  ng = "remain"
+  valid   = ["termination"]
+  invalid = ["remain"]
 }
 
 test "aws_ec2_fleet" "type" {
-  ok = "maintain"
-  ng = "remain"
+  valid   = ["maintain"]
+  invalid = ["remain"]
 }
 
 test "aws_ec2_transit_gateway" "auto_accept_shared_attachments" {
-  ok = "enable"
-  ng = "true"
+  valid   = ["enable"]
+  invalid = ["true"]
 }
 
 test "aws_ec2_transit_gateway" "default_route_table_association" {
-  ok = "disable"
-  ng = "false"
+  valid   = ["disable"]
+  invalid = ["false"]
 }
 
 test "aws_ec2_transit_gateway" "default_route_table_propagation" {
-  ok = "disable"
-  ng = "disabled"
+  valid   = ["disable"]
+  invalid = ["disabled"]
 }
 
 test "aws_ec2_transit_gateway" "dns_support" {
-  ok = "enable"
-  ng = "enabled"
+  valid   = ["enable"]
+  invalid = ["enabled"]
 }
 
 test "aws_ec2_transit_gateway_vpc_attachment" "ipv6_support" {
-  ok = "enable"
-  ng = "on"
+  valid   = ["enable"]
+  invalid = ["on"]
 }
 
 test "aws_instance" "instance_initiated_shutdown_behavior" {
-  ok = "stop"
-  ng = "restart"
+  valid   = ["stop"]
+  invalid = ["restart"]
 }
 
 test "aws_instance" "tenancy" {
-  ok = "host"
-  ng = "server"
+  valid   = ["host"]
+  invalid = ["server"]
 }
 
 test "aws_launch_template" "name" {
-  ok = "foo"
-  ng = "foo[bar]"
+  valid   = ["foo"]
+  invalid = ["foo[bar]"]
 }
 
 test "aws_launch_template" "instance_type" {
-  ok = "t2.micro"
-  ng = "t1.2xlarge"
+  valid   = ["t2.micro"]
+  invalid = ["t1.2xlarge"]
 }
 
 test "aws_placement_group" "strategy" {
-  ok = "cluster"
-  ng = "instance"
+  valid   = ["cluster"]
+  invalid = ["instance"]
 }
 
 test "aws_spot_fleet_request" "allocation_strategy" {
-  ok = "lowestPrice"
-  ng = "highestPrice"
+  valid   = ["lowestPrice"]
+  invalid = ["highestPrice"]
 }
 
 test "aws_spot_fleet_request" "instance_interruption_behaviour" {
-  ok = "hibernate"
-  ng = "restart"
+  valid   = ["hibernate"]
+  invalid = ["restart"]
 }

--- a/rules/models/mappings/ecr.hcl
+++ b/rules/models/mappings/ecr.hcl
@@ -34,6 +34,6 @@ mapping "aws_ecr_repository_policy" {
 }
 
 test "aws_ecr_lifecycle_policy" "repository" {
-  ok = "example"
-  ng = "example@com"
+  valid   = ["example"]
+  invalid = ["example@com"]
 }

--- a/rules/models/mappings/ecs.hcl
+++ b/rules/models/mappings/ecs.hcl
@@ -64,31 +64,31 @@ mapping "aws_ecs_task_set" {
 }
 
 test "aws_ecs_service" "launch_type" {
-  ok = "FARGATE"
-  ng = "POD"
+  valid   = ["FARGATE"]
+  invalid = ["POD"]
 }
 
 test "aws_ecs_service" "propagate_tags" {
-  ok = "SERVICE"
-  ng = "CONTAINER"
+  valid   = ["SERVICE"]
+  invalid = ["CONTAINER"]
 }
 
 test "aws_ecs_service" "scheduling_strategy" {
-  ok = "REPLICA"
-  ng = "SERVER"
+  valid   = ["REPLICA"]
+  invalid = ["SERVER"]
 }
 
 test "aws_ecs_task_definition" "ipc_mode" {
-  ok = "host"
-  ng = "vpc"
+  valid   = ["host"]
+  invalid = ["vpc"]
 }
 
 test "aws_ecs_task_definition" "network_mode" {
-  ok = "bridge"
-  ng = "vpc"
+  valid   = ["bridge"]
+  invalid = ["vpc"]
 }
 
 test "aws_ecs_task_definition" "pid_mode" {
-  ok = "task"
-  ng = "awsvpc"
+  valid   = ["task"]
+  invalid = ["awsvpc"]
 }

--- a/rules/models/mappings/efs.hcl
+++ b/rules/models/mappings/efs.hcl
@@ -36,11 +36,11 @@ mapping "aws_efs_mount_target" {
 }
 
 test "aws_efs_file_system" "performance_mode" {
-  ok = "generalPurpose"
-  ng = "minIO"
+  valid   = ["generalPurpose"]
+  invalid = ["minIO"]
 }
 
 test "aws_efs_file_system" "throughput_mode" {
-  ok = "bursting"
-  ng = "generalPurpose"
+  valid   = ["bursting"]
+  invalid = ["generalPurpose"]
 }

--- a/rules/models/mappings/eks.hcl
+++ b/rules/models/mappings/eks.hcl
@@ -37,6 +37,6 @@ mapping "aws_eks_node_group" {
 }
 
 test "aws_eks_cluster" "name" {
-  ok = "example"
-  ng = "@example"
+  valid   = ["example"]
+  invalid = ["@example"]
 }

--- a/rules/models/mappings/elasticache.hcl
+++ b/rules/models/mappings/elasticache.hcl
@@ -87,6 +87,6 @@ mapping "aws_elasticache_user_group" {
 }
 
 test "aws_elasticache_cluster" "az_mode" {
-  ok = "cross-az"
-  ng = "multi-az"
+  valid   = ["cross-az"]
+  invalid = ["multi-az"]
 }

--- a/rules/models/mappings/elastictranscoder.hcl
+++ b/rules/models/mappings/elastictranscoder.hcl
@@ -26,6 +26,6 @@ mapping "aws_elastictranscoder_preset" {
 }
 
 test "aws_elastictranscoder_preset" "container" {
-  ok = "mp4"
-  ng = "mp1"
+  valid   = ["mp4"]
+  invalid = ["mp1"]
 }

--- a/rules/models/mappings/elbv2.hcl
+++ b/rules/models/mappings/elbv2.hcl
@@ -123,21 +123,21 @@ mapping "aws_alb_target_group_attachment" {
 }
 
 test "aws_lb" "ip_address_type" {
-  ok = "ipv4"
-  ng = "ipv6"
+  valid   = ["ipv4"]
+  invalid = ["ipv6"]
 }
 
 test "aws_lb" "load_balancer_type" {
-  ok = "application"
-  ng = "classic"
+  valid   = ["application"]
+  invalid = ["classic"]
 }
 
 test "aws_lb_listener" "protocol" {
-  ok = "HTTPS"
-  ng = "INVALID"
+  valid   = ["HTTPS"]
+  invalid = ["INVALID"]
 }
 
 test "aws_lb_target_group" "target_type" {
-  ok = "lambda"
-  ng = "container"
+  valid   = ["lambda"]
+  invalid = ["container"]
 }

--- a/rules/models/pattern_rule_test.go.tmpl
+++ b/rules/models/pattern_rule_test.go.tmpl
@@ -10,35 +10,36 @@ import (
 
 func Test_{{ .RuleNameCC }}Rule(t *testing.T) {
 	cases := []struct {
-		Name     string
 		Content  string
 		Expected helper.Issues
 	}{
 		{
-			Name: "It includes invalid characters",
+			{{- range .Valid }}
 			Content: `
-resource "{{ .ResourceType }}" "foo" {
-	{{ .AttributeName }} = {{ .TestNG }}
-}`,
-			Expected: helper.Issues{
-				{
-					Rule:    New{{ .RuleNameCC }}Rule(),
-{{- if ne .Pattern "" }}
-					Message: `{{ .TestNG }} does not match valid pattern {{ .Pattern }}`,
-{{- end }}
-{{- if ne (len .Enum) 0 }}
-					Message: `{{ .TestNG }} is an invalid value as {{ .AttributeName }}`,
-{{- end }}
-				},
-			},
+resource "{{ $.ResourceType }}" "foo" {
+	{{ $.AttributeName }} = {{ . }}
+	}`,
+			Expected: helper.Issues{},
+			{{- end }}
 		},
 		{
-			Name: "It is valid",
+			{{- range .Invalid }}
 			Content: `
-resource "{{ .ResourceType }}" "foo" {
-	{{ .AttributeName }} = {{ .TestOK }}
-}`,
-			Expected: helper.Issues{},
+resource "{{ $.ResourceType }}" "foo" {
+	{{ $.AttributeName }} = {{ . }}
+	}`,
+			Expected: helper.Issues{
+				{
+					Rule:    New{{ $.RuleNameCC }}Rule(),
+					{{- if ne $.Pattern "" }}
+					Message: `{{ . }} does not match valid pattern {{ $.Pattern }}`,
+					{{- end }}
+					{{- if ne (len $.Enum) 0 }}
+					Message: `{{ . }} is an invalid value as {{ $.AttributeName }}`,
+					{{- end }}
+				},
+			},
+			{{- end }}
 		},
 	}
 


### PR DESCRIPTION
In #455 I found the model tests to be awkward to work with. `ok` and `ng` are confusing (no good?). Multiple test cases are not supported for the same attribute. 

Instead:

```hcl
test "aws_acmpca_certificate_authority" "type" {
  valid   = ["SUBORDINATE"]
  invalid = ["ORDINATE"]
}
```

* Clear attribute naming
* Multiple cases


I could break out the valid and invalid tests into separate sub-tests for easier identification but the naming seems like a waste. If anything, we shouldn't be allowing the SDK framework to call `t.Fatal`. We should be diffing the issues and printing the location of the mapping file in the error if there's a diff. Treating the generated test like a traditional Go test that the user would edit directly if failing is not the intended workflow. 

Separately, there are also bugs, where the tests don't account for truncation performed in the generated rules (see #455). 

Some diffs here (missing double quotes) are unintended consequences of refactoring the template and its calling code. 