### PR TITLE
Fix generated_code_checks workflow step

### DIFF
--- a/.github/workflows/generated_code_checks.yml
+++ b/.github/workflows/generated_code_checks.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Checkout submodules
-    - run: git submodule update --init --depth=0
+      run: git submodule update --init --depth=0
     - name: Set up Go
       uses: actions/setup-go@v3
       with:


### PR DESCRIPTION
The `generated_code_checks` workflow was not running due to syntax error in the workflow file introduced in https://github.com/terraform-linters/tflint-ruleset-aws/pull/450.