### PR TITLE
Fix Cosign v2 signing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,6 @@ checksum:
   name_template: 'checksums.txt'
 signs:
   - cmd: cosign
-    env:
-    - COSIGN_EXPERIMENTAL=1
     signature: '${artifact}.keyless.sig'
     certificate: '${artifact}.pem'
     output: true
@@ -35,6 +33,7 @@ signs:
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - --yes
 release:
   github:
     owner: terraform-linters


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-ruleset-aws/actions/runs/4454826275/jobs/7824266556
See https://github.com/terraform-linters/tflint-ruleset-aws/pull/458
See https://github.com/sigstore/cosign/blob/af5853d5a62550a460983eb987efd403ea4ce1a2/CHANGELOG.md

The `--yes` flag is required for Cosign v2's automated signing process. Also, `COSIGN_EXPERIMENTAL` is no longer required.