### PR TITLE
`aws_route_not_specified_target`: Add core_network_arn as target

### DIFF
--- a/docs/rules/aws_route_not_specified_target.md
+++ b/docs/rules/aws_route_not_specified_target.md
@@ -15,7 +15,7 @@ resource "aws_route" "foo" {
 $ tflint
 1 issue(s) found:
 
-Error: The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id or vpc_endpoint_id. (aws_route_not_specified_target)
+Error: The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id. (aws_route_not_specified_target)
 
   on template.tf line 1:
    1: resource "aws_route" "foo" {

--- a/rules/aws_route_not_specified_target.go
+++ b/rules/aws_route_not_specified_target.go
@@ -55,6 +55,7 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 			{Name: "vpc_endpoint_id"},
 			{Name: "carrier_gateway_id"},
 			{Name: "local_gateway_id"},
+			{Name: "core_network_arn"},
 		},
 	}, nil)
 	if err != nil {
@@ -78,7 +79,7 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 		if len(resource.Body.Attributes)-nullAttributes == 0 {
 			runner.EmitIssue(
 				r,
-				"The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id or vpc_endpoint_id.",
+				"The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id.",
 				resource.DefRange,
 			)
 		}

--- a/rules/aws_route_not_specified_target_test.go
+++ b/rules/aws_route_not_specified_target_test.go
@@ -22,7 +22,7 @@ resource "aws_route" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsRouteNotSpecifiedTargetRule(),
-					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id or vpc_endpoint_id.",
+					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 2, Column: 1},
@@ -104,7 +104,7 @@ resource "aws_route" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsRouteNotSpecifiedTargetRule(),
-					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id or vpc_endpoint_id.",
+					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 2, Column: 1},
@@ -119,6 +119,15 @@ resource "aws_route" "foo" {
 resource "aws_route" "foo" {
 	route_table_id = "rtb-1234abcd"
 	vpc_endpoint_id = "vpce-12345678abcdefgh"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "core_network_arn is specified",
+			Content: `
+resource "aws_route" "foo" {
+	route_table_id = "rtb-1234abcd"
+	core_network_arn = "arn:aws:networkmanager::230703758040:core-network/core-network-0ce39423cf52b4c76"
 }`,
 			Expected: helper.Issues{},
 		},


### PR DESCRIPTION
This adds `core_network_arn` as target, as it is one of valid targets in `aws_route` resource. 

Fixes #483 