### PR TITLE
resource_missing_tags: Ignore non-existent provider aliases

### DIFF
--- a/rules/aws_resource_missing_tags.go
+++ b/rules/aws_resource_missing_tags.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -169,21 +168,11 @@ func (r *AwsResourceMissingTagsRule) Check(runner tflint.Runner) error {
 			// Override the provider alias if defined
 			if val, ok := resource.Body.Attributes[providerAttributeName]; ok {
 				provider, diagnostics := aws.DecodeProviderConfigRef(val.Expr, "provider")
-				providerAlias = provider.Alias
-
-				if _, hasProvider := providerTagsMap[providerAlias]; !hasProvider {
-					errString := fmt.Sprintf(
-						"The aws provider with alias \"%s\" doesn't exist.",
-						providerAlias,
-					)
-					logger.Error("Error querying provider tags: %s", errString)
-					return errors.New(errString)
-				}
-
 				if diagnostics.HasErrors() {
 					logger.Error("error decoding provider: %w", diagnostics)
 					return diagnostics
 				}
+				providerAlias = provider.Alias
 			}
 
 			// If the resource has a tags attribute


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/518

The `aws_resource_missing_tags` rule implicitly expects the provider declaration to be in the same module if a resource has a `provider` argument. However, In child modules, provider declarations are passed implicitly or explicitly from the root module. In this case, it is not possible to refer to the provider's `default_tags` in this module.

https://developer.hashicorp.com/terraform/language/modules/develop/providers

The solution to this problem is to parse the provider declaration passed from the root module in module inspection. However, the current module inspection design has many limitations that unfortunately cannot be solved in this way. This issue is tracked in https://github.com/terraform-linters/tflint-plugin-sdk/issues/193

As a workaround, if the provider declaration is missing in the module, rather than returning an error, ignore the default tags. Conservatively, some default tags might apply, so you could skip the inspection, but there are probably many cases where it's more convenient to simply ignore the default tags.