### PR TITLE
resource_missing_tags: Fix panic for unknown and null values

### DIFF
--- a/rules/aws_resource_missing_tags.go
+++ b/rules/aws_resource_missing_tags.go
@@ -379,8 +379,11 @@ func stringInSlice(a string, list []string) bool {
 // If _any_ key is unknown, the entire value is considered unknown, since we can't know if a required tag might be matched by the unknown key.
 // Values are entirely ignored and can be unknown.
 func getKeysForValue(value cty.Value) (keys []string, known bool) {
-	if !value.CanIterateElements() {
+	if !value.CanIterateElements() || !value.IsKnown() {
 		return nil, false
+	}
+	if value.IsNull() {
+		return keys, true
 	}
 
 	return keys, !value.ForEachElement(func(key, _ cty.Value) bool {

--- a/rules/aws_resource_missing_tags_test.go
+++ b/rules/aws_resource_missing_tags_test.go
@@ -406,7 +406,7 @@ rule "aws_resource_missing_tags" {
 			Expected: helper.Issues{},
 		},
 		{
-			Name: "Unkown value maps should be silently ignored",
+			Name: "Unknown value maps should be silently ignored",
 			Content: `variable "aws_region" {
   default = "us-east-1"
   type = string


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/528
See also https://github.com/terraform-linters/tflint-ruleset-aws/pull/517

`CanIterateElements` seems to cause panic in unknown and NULL cases. This PR adds handling for these values in `getKeysForValue` and fixes the panic.

I was looking into why this pattern wasn't detected in unit tests, and it seems that this bug only occurs with iterable typed unknown values. The evaluation functionality provided by the SDK is unaware of the variable type, so this bug cannot be reproduced in a unit test.