### PR TITLE
`s3_bucket_name`: fix docs

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -73,7 +73,7 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)|Disallow deprecated runtimes for Lambda Function|✔|
 |[aws_resource_missing_tags](aws_resource_missing_tags.md)|Require specific tags for all AWS resource types that support them||
-|[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the specified naming rules||
+|[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the naming rules|✔|
 
 ### SDK-based Validations
 

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -73,7 +73,7 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)|Disallow deprecated runtimes for Lambda Function|✔|
 |[aws_resource_missing_tags](aws_resource_missing_tags.md)|Require specific tags for all AWS resource types that support them||
-|[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the specified naming rules||
+|[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the naming rules|✔|
 
 ### SDK-based Validations
 

--- a/docs/rules/aws_s3_bucket_name.md
+++ b/docs/rules/aws_s3_bucket_name.md
@@ -1,6 +1,6 @@
 # aws_s3_bucket_name
 
-Ensures all S3 bucket names match the specified naming rules.
+Ensures all S3 bucket names match the naming rules.
 
 ## Configuration
 


### PR DESCRIPTION
Checking the enabled default box:

https://github.com/terraform-linters/tflint-ruleset-aws/blob/master/rules/aws_s3_bucket_name.go#L39C1-L42C2

Removing the `specified` because that's not required by the rule anymore.