### PR TITLE
`s3_bucket_name`: add all documented naming rules

### DIFF
--- a/integration/rule-config/result.json
+++ b/integration/rule-config/result.json
@@ -19,6 +19,26 @@
         }
       },
       "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_s3_bucket_name",
+        "severity": "error",
+        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.27.0/docs/rules/aws_s3_bucket_name.md"
+      },
+      "message": "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-). (name: \"foo_bar\", regex: \"[^a-z0-9\\\\.\\\\-]\")",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 2,
+          "column": 12
+        },
+        "end": {
+          "line": 2,
+          "column": 21
+        }
+      },
+      "callers": []
     }
   ],
   "errors": []

--- a/rules/aws_s3_bucket_name.go
+++ b/rules/aws_s3_bucket_name.go
@@ -81,7 +81,7 @@ func (r *AwsS3BucketNameRule) Check(runner tflint.Runner) error {
 	}{
 		{
 			Regexp: *regexp.MustCompile(fmt.Sprintf(
-				"^(.{0,%d})?(.{%d,})?$",
+				"^.{0,%d}$|.{%d,}$",
 				bucketNameMinLength-1,
 				bucketNameMaxLength+1,
 			)),
@@ -96,12 +96,8 @@ func (r *AwsS3BucketNameRule) Check(runner tflint.Runner) error {
 			Description: "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).",
 		},
 		{
-			Regexp:      *regexp.MustCompile("^[^a-z0-9]"),
-			Description: "Bucket names must begin with a lowercase letter or number.",
-		},
-		{
-			Regexp:      *regexp.MustCompile("[^a-z0-9]$"),
-			Description: "Bucket names must end with a lowercase letter or number.",
+			Regexp:      *regexp.MustCompile("^[^a-z0-9]|[^a-z0-9]$"),
+			Description: "Bucket names must begin and end with a lowercase letter or number.",
 		},
 		{
 			Regexp:      *regexp.MustCompile("\\.\\."),
@@ -112,7 +108,7 @@ func (r *AwsS3BucketNameRule) Check(runner tflint.Runner) error {
 			Description: "Bucket names must not start with the prefix 'xn--'.",
 		},
 		{
-			Regexp:      *regexp.MustCompile("^(sthree-dwa|sthree-configurator21)"),
+			Regexp:      *regexp.MustCompile("^(sthree-|sthree-configurator)"),
 			Description: "Bucket names must not start with the prefix 'sthree-' and the prefix 'sthree-configurator'.",
 		},
 		{

--- a/rules/aws_s3_bucket_name.go
+++ b/rules/aws_s3_bucket_name.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
@@ -73,6 +74,57 @@ func (r *AwsS3BucketNameRule) Check(runner tflint.Runner) error {
 	bucketNameMinLength := 3
 	bucketNameMaxLength := 63
 
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+	regexRules := []struct {
+		Regexp      regexp.Regexp
+		Description string
+	}{
+		{
+			Regexp: *regexp.MustCompile(fmt.Sprintf(
+				"^(.{0,%d})?(.{%d,})?$",
+				bucketNameMinLength-1,
+				bucketNameMaxLength+1,
+			)),
+			Description: fmt.Sprintf(
+				"Bucket names must be between %d (min) and %d (max) characters long.",
+				bucketNameMinLength,
+				bucketNameMaxLength,
+			),
+		},
+		{
+			Regexp:      *regexp.MustCompile("[^a-z0-9\\.\\-]"),
+			Description: "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).",
+		},
+		{
+			Regexp:      *regexp.MustCompile("^[^a-z0-9]"),
+			Description: "Bucket names must begin with a lowercase letter or number.",
+		},
+		{
+			Regexp:      *regexp.MustCompile("[^a-z0-9]$"),
+			Description: "Bucket names must end with a lowercase letter or number.",
+		},
+		{
+			Regexp:      *regexp.MustCompile("\\.\\."),
+			Description: "Bucket names must not contain two adjacent periods.",
+		},
+		{
+			Regexp:      *regexp.MustCompile("^xn--"),
+			Description: "Bucket names must not start with the prefix 'xn--'.",
+		},
+		{
+			Regexp:      *regexp.MustCompile("^(sthree-dwa|sthree-configurator21)"),
+			Description: "Bucket names must not start with the prefix 'sthree-' and the prefix 'sthree-configurator'.",
+		},
+		{
+			Regexp:      *regexp.MustCompile("-s3alias$"),
+			Description: "Bucket names must not end with the suffix '-s3alias'.",
+		},
+		{
+			Regexp:      *regexp.MustCompile("--ol-s3$"),
+			Description: "Bucket names must not end with the suffix '--ol-s3'.",
+		},
+	}
+
 	for _, resource := range resources.Blocks {
 		attribute, exists := resource.Body.Attributes[r.attributeName]
 		if !exists {
@@ -100,12 +152,23 @@ func (r *AwsS3BucketNameRule) Check(runner tflint.Runner) error {
 				}
 			}
 
-			if len(name) < bucketNameMinLength || len(name) > bucketNameMaxLength {
-				runner.EmitIssue(
-					r,
-					fmt.Sprintf("Bucket name %q must be between %d and %d characters", name, bucketNameMinLength, bucketNameMaxLength),
-					attribute.Expr.Range(),
-				)
+      nameAsIP := net.ParseIP(name)
+      if nameAsIP != nil && net.IP.To4(nameAsIP) != nil {
+        runner.EmitIssue(
+          r,
+          fmt.Sprintf(`Bucket names must not be formatted as an IP address. (name: %q)`, name),
+          attribute.Expr.Range(),
+        )
+      }
+
+			for _, rule := range regexRules {
+				if rule.Regexp.MatchString(name) {
+					runner.EmitIssue(
+						r,
+						fmt.Sprintf(`%s (name: %q, regex: %q)`, rule.Description, name, rule.Regexp.String()),
+						attribute.Expr.Range(),
+					)
+				}
 			}
 			return nil
 		}, nil)

--- a/rules/aws_s3_bucket_name_test.go
+++ b/rules/aws_s3_bucket_name_test.go
@@ -127,7 +127,7 @@ resource "aws_s3_bucket" "too_long" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsS3BucketNameRule(),
-					Message: `Bucket name "a-really-ultra-hiper-super-long-foo-bar-baz-bucket-name.domain.test" must be between 3 and 63 characters`,
+					Message: `Bucket names must be between 3 (min) and 63 (max) characters long. (name: "a-really-ultra-hiper-super-long-foo-bar-baz-bucket-name.domain.test", regex: "^(.{0,2})?(.{64,})?$")`,
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},

--- a/rules/aws_s3_bucket_name_test.go
+++ b/rules/aws_s3_bucket_name_test.go
@@ -120,18 +120,196 @@ rule "aws_s3_bucket_name" {
 		{
 			Name: "length",
 			Content: `
-resource "aws_s3_bucket" "too_long" {
+resource "aws_s3_bucket" "max_length" {
   bucket = "a-really-ultra-hiper-super-long-foo-bar-baz-bucket-name.domain.test"
+}
+
+resource "aws_s3_bucket" "min_length" {
+  bucket = "xy"
 }
 `,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsS3BucketNameRule(),
-					Message: `Bucket names must be between 3 (min) and 63 (max) characters long. (name: "a-really-ultra-hiper-super-long-foo-bar-baz-bucket-name.domain.test", regex: "^(.{0,2})?(.{64,})?$")`,
+					Message: `Bucket names must be between 3 (min) and 63 (max) characters long. (name: "a-really-ultra-hiper-super-long-foo-bar-baz-bucket-name.domain.test", regex: "^.{0,2}$|.{64,}$")`,
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
 						End:      hcl.Pos{Line: 3, Column: 81},
+					},
+				},
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must be between 3 (min) and 63 (max) characters long. (name: "xy", regex: "^.{0,2}$|.{64,}$")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 7, Column: 12},
+						End:      hcl.Pos{Line: 7, Column: 16},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid_characters",
+			Content: `
+resource "aws_s3_bucket" "invalid_characters" {
+  bucket = "who_am_I?.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-). (name: "who_am_I?.com", regex: "[^a-z0-9\\.\\-]")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid_begin_end",
+			Content: `
+resource "aws_s3_bucket" "invalid_begin" {
+  bucket = ".domain.com"
+}
+
+resource "aws_s3_bucket" "invalid_end" {
+  bucket = "domain.com."
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must begin and end with a lowercase letter or number. (name: ".domain.com", regex: "^[^a-z0-9]|[^a-z0-9]$")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 25},
+					},
+				},
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must begin and end with a lowercase letter or number. (name: "domain.com.", regex: "^[^a-z0-9]|[^a-z0-9]$")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 7, Column: 12},
+						End:      hcl.Pos{Line: 7, Column: 25},
+					},
+				},
+			},
+		},
+		{
+			Name: "adjacent_periods",
+			Content: `
+resource "aws_s3_bucket" "adjacent_periods" {
+  bucket = "domain..com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must not contain two adjacent periods. (name: "domain..com", regex: "\\.\\.")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 25},
+					},
+				},
+			},
+		},
+		{
+			Name: "ipv4",
+			Content: `
+resource "aws_s3_bucket" "ipv4" {
+  bucket = "192.168.0.254"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must not be formatted as an IP address. (name: "192.168.0.254")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid_prefix_xn",
+			Content: `
+resource "aws_s3_bucket" "invalid_prefix_xn" {
+  bucket = "xn--domain.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must not start with the prefix 'xn--'. (name: "xn--domain.com", regex: "^xn--")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 28},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid_prefix_sthree",
+			Content: `
+resource "aws_s3_bucket" "invalid_prefix_sthree" {
+  bucket = "sthree-domain.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must not start with the prefix 'sthree-' and the prefix 'sthree-configurator'. (name: "sthree-domain.com", regex: "^(sthree-|sthree-configurator)")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 31},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid_suffix_s3alias",
+			Content: `
+resource "aws_s3_bucket" "invalid_suffix_s3alias" {
+  bucket = "domain-s3alias"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must not end with the suffix '-s3alias'. (name: "domain-s3alias", regex: "-s3alias$")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 28},
+					},
+				},
+			},
+		},
+		{
+			Name: "invalid_suffix_ols3",
+			Content: `
+resource "aws_s3_bucket" "invalid_suffix_ols3" {
+  bucket = "domain--ol-s3"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsS3BucketNameRule(),
+					Message: `Bucket names must not end with the suffix '--ol-s3'. (name: "domain--ol-s3", regex: "--ol-s3$")`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 27},
 					},
 				},
 			},


### PR DESCRIPTION
From [this discussion](https://github.com/terraform-linters/tflint-ruleset-aws/discussions/570).

Also an alternative to remove hardcoded values from [this past issue](https://github.com/terraform-linters/tflint-ruleset-aws/pull/554#discussion_r1336202012).