### PR TITLE
Fix aws_acm_certificate.private_key mapping and remove the rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -92,7 +92,6 @@ These rules enforce best practices and naming conventions:
 |aws_acm_certificate_invalid_certificate_authority_arn|✔|
 |aws_acm_certificate_invalid_certificate_body|✔|
 |aws_acm_certificate_invalid_certificate_chain|✔|
-|aws_acm_certificate_invalid_private_key|✔|
 |aws_acm_certificate_validation_invalid_certificate_arn|✔|
 |aws_acmpca_certificate_authority_certificate_invalid_certificate_authority_arn|✔|
 |aws_acmpca_certificate_authority_invalid_type|✔|

--- a/rules/models/mappings/acm.hcl
+++ b/rules/models/mappings/acm.hcl
@@ -4,7 +4,7 @@ mapping "aws_acm_certificate" {
   // domain_name            = DomainNameString
   subject_alternative_names = DomainList
   // validation_method      = ValidationMethod
-  private_key               = PrivateKey
+  private_key               = PrivateKeyBlob
   certificate_body          = CertificateBody
   certificate_chain         = CertificateChain
   certificate_authority_arn = PcaArn

--- a/rules/models/provider.go
+++ b/rules/models/provider.go
@@ -17,7 +17,6 @@ var Rules = []tflint.Rule{
 	NewAwsAcmCertificateInvalidCertificateAuthorityArnRule(),
 	NewAwsAcmCertificateInvalidCertificateBodyRule(),
 	NewAwsAcmCertificateInvalidCertificateChainRule(),
-	NewAwsAcmCertificateInvalidPrivateKeyRule(),
 	NewAwsAcmCertificateValidationInvalidCertificateArnRule(),
 	NewAwsAcmpcaCertificateAuthorityCertificateInvalidCertificateAuthorityArnRule(),
 	NewAwsAcmpcaCertificateAuthorityInvalidTypeRule(),


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/573

Looking at the AWS provider's implementation, `aws_acm_certificate.private_key` refers to `PrivateKeyBlob`, not `PrivateKey`.

https://github.com/hashicorp/terraform-provider-aws/blob/v5.26.0/internal/service/acm/certificate.go#L382
https://github.com/aws/aws-sdk-go/blob/v1.48.0/models/apis/acm/2015-12-08/api-2.json#L596

This PR fixes the mapping and regenerate rules. Note that as a result, there is a breaking change in which the `aws_acm_certificate_invalid_private_key` rule is removed.