### PR TITLE
generator: use terraform-json types for provider schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 )
 
 require (
+	github.com/hashicorp/terraform-json v0.20.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/net v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
+github.com/hashicorp/terraform-json v0.20.0 h1:cJcvn4gIOTi0SD7pIy+xiofV1zFA3hza+6K+fo52IX8=
+github.com/hashicorp/terraform-json v0.20.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=

--- a/rules/api/generator/main.go
+++ b/rules/api/generator/main.go
@@ -1,4 +1,4 @@
-// +build generators
+//go:build generators
 
 package main
 
@@ -99,18 +99,10 @@ func dataType(resource, attribute string) string {
 		panic(fmt.Sprintf("`%s.%s` not found in the Terraform schema", resource, attribute))
 	}
 
-	switch ty := attrSchema.Type.(type) {
-	case string:
-		if ty != "string" {
-			panic(fmt.Errorf("Unexpected data type: %#v", attrSchema.Type))
-		}
+	if ty := attrSchema.AttributeType.FriendlyName(); ty == "string" {
 		return "string"
-	case []interface{}:
-		if len(ty) != 2 || !(ty[0] == "set" && ty[1] == "string") {
-			panic(fmt.Errorf("Unexpected data type: %#v", attrSchema.Type))
-		}
+	} else if attrSchema.AttributeType.IsSetType() || attrSchema.AttributeType.IsListType() {
 		return "list"
-	default:
-		panic(fmt.Errorf("Unexpected data type: %#v", attrSchema.Type))
 	}
+	panic(fmt.Errorf("Unexpected data type: %#v", attrSchema.AttributeType))
 }

--- a/rules/generator-utils/schema.go
+++ b/rules/generator-utils/schema.go
@@ -3,43 +3,19 @@ package utils
 import (
 	"encoding/json"
 	"io/ioutil"
+
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
-type Schema struct {
-	ProviderSchemas ProviderSchemas `json:"provider_schemas"`
-}
-
-type ProviderSchemas struct {
-	AWS ProviderSchema `json:"registry.terraform.io/hashicorp/aws"`
-}
-
-type ProviderSchema struct {
-	ResourceSchemas map[string]ResourceSchema `json:"resource_schemas"`
-}
-
-type ResourceSchema struct {
-	Block BlockSchema `json:"block"`
-}
-
-type BlockSchema struct {
-	Attributes map[string]AttributeSchema `json:"attributes"`
-	BlockTypes map[string]ResourceSchema  `json:"block_types"`
-}
-
-type AttributeSchema struct {
-	Type      interface{} `json:"type"`
-	Sensitive bool        `json:"sensitive"`
-}
-
-func LoadProviderSchema(path string) ProviderSchema {
+func LoadProviderSchema(path string) *tfjson.ProviderSchema {
 	src, err := ioutil.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}
 
-	var schema Schema
+	var schema tfjson.ProviderSchemas
 	if err := json.Unmarshal(src, &schema); err != nil {
 		panic(err)
 	}
-	return schema.ProviderSchemas.AWS
+	return schema.Schemas["registry.terraform.io/hashicorp/aws"]
 }

--- a/rules/models/generator/doc.go
+++ b/rules/models/generator/doc.go
@@ -1,4 +1,4 @@
-// +build generators
+//go:build generators
 
 package main
 

--- a/rules/models/generator/provider.go
+++ b/rules/models/generator/provider.go
@@ -1,4 +1,4 @@
-// +build generators
+//go:build generators
 
 package main
 

--- a/rules/models/generator/rule.go
+++ b/rules/models/generator/rule.go
@@ -1,4 +1,4 @@
-// +build generators
+//go:build generators
 
 package main
 
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	tfjson "github.com/hashicorp/terraform-json"
 	utils "github.com/terraform-linters/tflint-ruleset-aws/rules/generator-utils"
 )
 
@@ -24,7 +25,7 @@ type ruleMeta struct {
 	TestNG        string
 }
 
-func generateRuleFile(resource, attribute string, model map[string]interface{}, schema utils.AttributeSchema) {
+func generateRuleFile(resource, attribute string, model map[string]interface{}, schema *tfjson.SchemaAttribute) {
 	ruleName := makeRuleName(resource, attribute)
 
 	meta := &ruleMeta{

--- a/rules/tags/generator/main.go
+++ b/rules/tags/generator/main.go
@@ -1,4 +1,4 @@
-// +build generators
+//go:build generators
 
 package main
 


### PR DESCRIPTION
Update generator-util package to use provider types from [terraform-json](https://github.com/hashicorp/terraform-json) instead of duplicating them here.

Also update a go [build tag](https://pkg.go.dev/cmd/go#hdr-Build_constraints) to the go 1.18+ syntax