### PR TITLE
fix: prevent runtime error when instanceType/nodeType have no dot

### DIFF
--- a/rules/aws_db_instance_previous_type.go
+++ b/rules/aws_db_instance_previous_type.go
@@ -70,7 +70,12 @@ func (r *AwsDBInstancePreviousTypeRule) Check(runner tflint.Runner) error {
 		}
 
 		err := runner.EvaluateExpr(attribute.Expr, func(instanceType string) error {
-			if r.previousInstanceTypes[strings.Split(instanceType, ".")[1]] {
+			parts := strings.Split(instanceType, ".")
+			if len(parts) < 3 {
+				return nil
+			}
+
+			if r.previousInstanceTypes[parts[1]] {
 				runner.EmitIssue(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),

--- a/rules/aws_db_instance_previous_type_test.go
+++ b/rules/aws_db_instance_previous_type_test.go
@@ -39,6 +39,14 @@ resource "aws_db_instance" "mysql" {
 }`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "test is not previous type",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "test"
+}`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewAwsDBInstancePreviousTypeRule()

--- a/rules/aws_elasticache_replication_group_previous_type.go
+++ b/rules/aws_elasticache_replication_group_previous_type.go
@@ -61,7 +61,12 @@ func (r *AwsElastiCacheReplicationGroupPreviousTypeRule) Check(runner tflint.Run
 		}
 
 		err := runner.EvaluateExpr(attribute.Expr, func(nodeType string) error {
-			if previousElastiCacheNodeTypes[strings.Split(nodeType, ".")[1]] {
+			parts := strings.Split(nodeType, ".")
+			if len(parts) != 3 {
+				return nil
+			}
+
+			if previousElastiCacheNodeTypes[parts[1]] {
 				runner.EmitIssue(
 					r,
 					fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),

--- a/rules/aws_elasticache_replication_group_previous_type_test.go
+++ b/rules/aws_elasticache_replication_group_previous_type_test.go
@@ -39,6 +39,14 @@ resource "aws_elasticache_replication_group" "redis" {
 }`,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "test is not previous type",
+			Content: `
+resource "aws_elasticache_replication_group" "redis" {
+    node_type = "test"
+}`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewAwsElastiCacheReplicationGroupPreviousTypeRule()


### PR DESCRIPTION
This happened to us when mocking the terraform variable for testing.