### PR TITLE
Add aws_iam_access_key_forbidden rule

### DIFF
--- a/docs/rules/aws_iam_access_key_forbidden.md
+++ b/docs/rules/aws_iam_access_key_forbidden.md
@@ -1,0 +1,29 @@
+# aws_iam_access_key_forbidden
+
+Disallow using `aws_iam_access_key` resources.
+
+## Example
+
+```hcl
+resource "aws_iam_access_key" "my_key" {
+  user = "my-user"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "aws_iam_access_key" resources are forbidden. (aws_iam_access_key_forbidden)
+
+  on main.tf line 1:
+   1: resource "aws_iam_access_key" "my_key" {
+```
+
+## Why
+
+Managing IAM access keys with terraform leads to sensitive secrets being stored in plain text in terraform state files.
+
+## How To Fix
+
+Do not manage IAM access keys with terraform, or use the [pgp_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key#pgp_key) argument and protect your backend state file judiciously.

--- a/rules/aws_iam_access_key_forbidden.go
+++ b/rules/aws_iam_access_key_forbidden.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsIAMAccessKeyForbiddenRule checks that aws_iam_access_key resource is not used
+type AwsIAMAccessKeyForbiddenRule struct {
+	tflint.DefaultRule
+
+	resourceType string
+}
+
+// NewAwsIAMAccessKeyForbiddenRule returns new rule with default attributes
+func NewAwsIAMAccessKeyForbiddenRule() *AwsIAMAccessKeyForbiddenRule {
+	return &AwsIAMAccessKeyForbiddenRule{
+		resourceType: "aws_iam_access_key",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsIAMAccessKeyForbiddenRule) Name() string {
+	return "aws_iam_access_key_forbidden"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsIAMAccessKeyForbiddenRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *AwsIAMAccessKeyForbiddenRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsIAMAccessKeyForbiddenRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks that no aws_iam_access_key resources are being used
+func (r *AwsIAMAccessKeyForbiddenRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		runner.EmitIssue(
+			r,
+			"\"aws_iam_access_key\" resources are forbidden.",
+			resource.DefRange,
+		)
+	}
+
+	return nil
+}

--- a/rules/aws_iam_access_key_forbidden_test.go
+++ b/rules/aws_iam_access_key_forbidden_test.go
@@ -1,0 +1,48 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsIAMAccessKeyForbidden(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "basic",
+			Content: `
+resource "aws_iam_access_key" "my_key" {
+  user = "my-user"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsIAMAccessKeyForbiddenRule(),
+					Message: "\"aws_iam_access_key\" resources are forbidden.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 39},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsIAMAccessKeyForbiddenRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -40,6 +40,7 @@ var manualRules = []tflint.Rule{
 	NewAwsSecurityGroupInvalidProtocolRule(),
 	NewAwsSecurityGroupRuleInvalidProtocolRule(),
 	NewAwsProviderMissingDefaultTagsRule(),
+	NewAwsIAMAccessKeyForbiddenRule(),
 }
 
 // Rules is a list of all rules


### PR DESCRIPTION
Add a new `aws_iam_access_key_forbidden` rule that prevents the creation of IAM access keys through terraform. The rule is disabled by default.