### PR TITLE
mappings: Migrate import paths from aws-sdk-go to aws-sdk-ruby

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "rules/models/aws-sdk-go"]
-	path = rules/models/aws-sdk-go
-	url = https://github.com/aws/aws-sdk-go
+[submodule "rules/models/aws-sdk-ruby"]
+	path = rules/models/aws-sdk-ruby
+	url = https://github.com/aws/aws-sdk-ruby

--- a/rules/models/aws_fsx_ontap_file_system_invalid_deployment_type.go
+++ b/rules/models/aws_fsx_ontap_file_system_invalid_deployment_type.go
@@ -28,6 +28,7 @@ func NewAwsFsxOntapFileSystemInvalidDeploymentTypeRule() *AwsFsxOntapFileSystemI
 			"MULTI_AZ_1",
 			"SINGLE_AZ_1",
 			"SINGLE_AZ_2",
+			"MULTI_AZ_2",
 		},
 	}
 }

--- a/rules/models/aws_fsx_openzfs_file_system_invalid_deployment_type.go
+++ b/rules/models/aws_fsx_openzfs_file_system_invalid_deployment_type.go
@@ -27,6 +27,8 @@ func NewAwsFsxOpenzfsFileSystemInvalidDeploymentTypeRule() *AwsFsxOpenzfsFileSys
 		enum: []string{
 			"SINGLE_AZ_1",
 			"SINGLE_AZ_2",
+			"SINGLE_AZ_HA_1",
+			"SINGLE_AZ_HA_2",
 			"MULTI_AZ_1",
 		},
 	}

--- a/rules/models/mappings/access-analyzer.hcl
+++ b/rules/models/mappings/access-analyzer.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/accessanalyzer/2019-11-01/api-2.json"
+import = "aws-sdk-ruby/apis/accessanalyzer/2019-11-01/api-2.json"
 
 mapping "aws_accessanalyzer_analyzer" {
   analyzer_name = Name

--- a/rules/models/mappings/account.hcl
+++ b/rules/models/mappings/account.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/account/2021-02-01/api-2.json"
+import = "aws-sdk-ruby/apis/account/2021-02-01/api-2.json"
 
 mapping "aws_account_alternate_contact" {
   account_id = AccountId

--- a/rules/models/mappings/acm-pca.hcl
+++ b/rules/models/mappings/acm-pca.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/acm-pca/2017-08-22/api-2.json"
+import = "aws-sdk-ruby/apis/acm-pca/2017-08-22/api-2.json"
 
 mapping "aws_acmpca_certificate" {
   certificate_authority_arn   = Arn

--- a/rules/models/mappings/acm.hcl
+++ b/rules/models/mappings/acm.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/acm/2015-12-08/api-2.json"
+import = "aws-sdk-ruby/apis/acm/2015-12-08/api-2.json"
 
 mapping "aws_acm_certificate" {
   // domain_name            = DomainNameString

--- a/rules/models/mappings/amplify.hcl
+++ b/rules/models/mappings/amplify.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/amplify/2017-07-25/api-2.json"
+import = "aws-sdk-ruby/apis/amplify/2017-07-25/api-2.json"
 
 mapping "aws_amplify_app" {
   name = Name

--- a/rules/models/mappings/apigateway.hcl
+++ b/rules/models/mappings/apigateway.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/apigateway/2015-07-09/api-2.json"
+import = "aws-sdk-ruby/apis/apigateway/2015-07-09/api-2.json"
 
 mapping "aws_api_gateway_documentation_part" {
   location = DocumentationPartLocation

--- a/rules/models/mappings/apigatewayv2.hcl
+++ b/rules/models/mappings/apigatewayv2.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/apigatewayv2/2018-11-29/api-2.json"
+import = "aws-sdk-ruby/apis/apigatewayv2/2018-11-29/api-2.json"
 
 mapping "aws_apigatewayv2_api" {
   name = StringWithLengthBetween1And128

--- a/rules/models/mappings/appconfig.hcl
+++ b/rules/models/mappings/appconfig.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/appconfig/2019-10-09/api-2.json"
+import = "aws-sdk-ruby/apis/appconfig/2019-10-09/api-2.json"
 
 mapping "aws_appconfig_application" {
   name = Name

--- a/rules/models/mappings/application-autoscaling.hcl
+++ b/rules/models/mappings/application-autoscaling.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/application-autoscaling/2016-02-06/api-2.json"
+import = "aws-sdk-ruby/apis/application-autoscaling/2016-02-06/api-2.json"
 
 mapping "aws_appautoscaling_policy" {
   policy_type        = PolicyType

--- a/rules/models/mappings/appmesh.hcl
+++ b/rules/models/mappings/appmesh.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/appmesh/2019-01-25/api-2.json"
+import = "aws-sdk-ruby/apis/appmesh/2019-01-25/api-2.json"
 
 mapping "aws_appmesh_gateway_route" {
   name = ResourceName

--- a/rules/models/mappings/apprunner.hcl
+++ b/rules/models/mappings/apprunner.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/apprunner/2020-05-15/api-2.json"
+import = "aws-sdk-ruby/apis/apprunner/2020-05-15/api-2.json"
 
 mapping "aws_apprunner_auto_scaling_configuration_version" {
   auto_scaling_configuration_name = AutoScalingConfigurationName

--- a/rules/models/mappings/appstream.hcl
+++ b/rules/models/mappings/appstream.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/appstream/2016-12-01/api-2.json"
+import = "aws-sdk-ruby/apis/appstream/2016-12-01/api-2.json"
 
 mapping "aws_appstream_directory_config" {
   directory_name = DirectoryName

--- a/rules/models/mappings/appsync.hcl
+++ b/rules/models/mappings/appsync.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/appsync/2017-07-25/api-2.json"
+import = "aws-sdk-ruby/apis/appsync/2017-07-25/api-2.json"
 
 mapping "aws_appsync_datasource" {
   name = ResourceName

--- a/rules/models/mappings/athena.hcl
+++ b/rules/models/mappings/athena.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/athena/2017-05-18/api-2.json"
+import = "aws-sdk-ruby/apis/athena/2017-05-18/api-2.json"
 
 mapping "aws_athena_database" {
   name = DatabaseString

--- a/rules/models/mappings/autoscaling.hcl
+++ b/rules/models/mappings/autoscaling.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/autoscaling/2011-01-01/api-2.json"
+import = "aws-sdk-ruby/apis/autoscaling/2011-01-01/api-2.json"
 
 mapping "aws_launch_configuration" {
   name                           = CreateLaunchConfigurationType

--- a/rules/models/mappings/backup.hcl
+++ b/rules/models/mappings/backup.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/backup/2018-11-15/api-2.json"
+import = "aws-sdk-ruby/apis/backup/2018-11-15/api-2.json"
 
 mapping "aws_backup_selection" {
   name = BackupSelectionName

--- a/rules/models/mappings/batch.hcl
+++ b/rules/models/mappings/batch.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/batch/2016-08-10/api-2.json"
+import = "aws-sdk-ruby/apis/batch/2016-08-10/api-2.json"
 
 mapping "aws_batch_compute_environment" {
   state = CEState

--- a/rules/models/mappings/budgets.hcl
+++ b/rules/models/mappings/budgets.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/budgets/2016-10-20/api-2.json"
+import = "aws-sdk-ruby/apis/budgets/2016-10-20/api-2.json"
 
 mapping "aws_budgets_budget" {
   account_id  = AccountId

--- a/rules/models/mappings/chime.hcl
+++ b/rules/models/mappings/chime.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/chime/2018-05-01/api-2.json"
+import = "aws-sdk-ruby/apis/chime/2018-05-01/api-2.json"
 
 mapping "aws_chime_voice_connector" {
   name = VoiceConnectorName

--- a/rules/models/mappings/cloud9.hcl
+++ b/rules/models/mappings/cloud9.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/cloud9/2017-09-23/api-2.json"
+import = "aws-sdk-ruby/apis/cloud9/2017-09-23/api-2.json"
 
 mapping "aws_cloud9_environment_ec2" {
   name                        = EnvironmentName

--- a/rules/models/mappings/cloudformation.hcl
+++ b/rules/models/mappings/cloudformation.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/cloudformation/2010-05-15/api-2.json"
+import = "aws-sdk-ruby/apis/cloudformation/2010-05-15/api-2.json"
 
 mapping "aws_cloudformation_stack" {
   template_url = TemplateURL

--- a/rules/models/mappings/cloudfront.hcl
+++ b/rules/models/mappings/cloudfront.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/cloudfront/2020-05-31/api-2.json"
+import = "aws-sdk-ruby/apis/cloudfront/2020-05-31/api-2.json"
 
 mapping "aws_cloudfront_cache_policy" {
   parameters_in_cache_key_and_forwarded_to_origin = ParametersInCacheKeyAndForwardedToOrigin

--- a/rules/models/mappings/cloudhsmv2.hcl
+++ b/rules/models/mappings/cloudhsmv2.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/cloudhsmv2/2017-04-28/api-2.json"
+import = "aws-sdk-ruby/apis/cloudhsmv2/2017-04-28/api-2.json"
 
 mapping "aws_cloudhsm_v2_cluster" {
   source_backup_identifier = BackupId

--- a/rules/models/mappings/cloudwatch-event.hcl
+++ b/rules/models/mappings/cloudwatch-event.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/events/2015-10-07/api-2.json"
+import = "aws-sdk-ruby/apis/events/2015-10-07/api-2.json"
 
 mapping "aws_cloudwatch_event_api_destination" {
   name = ApiDestinationName

--- a/rules/models/mappings/cloudwatch-log.hcl
+++ b/rules/models/mappings/cloudwatch-log.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/logs/2014-03-28/api-2.json"
+import = "aws-sdk-ruby/apis/logs/2014-03-28/api-2.json"
 
 mapping "aws_cloudwatch_log_destination" {
   name = DestinationName

--- a/rules/models/mappings/cloudwatch-metric.hcl
+++ b/rules/models/mappings/cloudwatch-metric.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/monitoring/2010-08-01/api-2.json"
+import = "aws-sdk-ruby/apis/monitoring/2010-08-01/api-2.json"
 
 mapping "aws_cloudwatch_metric_alarm" {
   alarm_name                            = AlarmName

--- a/rules/models/mappings/codeartifact.hcl
+++ b/rules/models/mappings/codeartifact.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/codeartifact/2018-09-22/api-2.json"
+import = "aws-sdk-ruby/apis/codeartifact/2018-09-22/api-2.json"
 
 mapping "aws_codeartifact_domain" {
   domain = DomainName

--- a/rules/models/mappings/codebuild.hcl
+++ b/rules/models/mappings/codebuild.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/codebuild/2016-10-06/api-2.json"
+import = "aws-sdk-ruby/apis/codebuild/2016-10-06/api-2.json"
 
 mapping "aws_codebuild_project" {
   build_timeout = TimeOut

--- a/rules/models/mappings/codecommit.hcl
+++ b/rules/models/mappings/codecommit.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/codecommit/2015-04-13/api-2.json"
+import = "aws-sdk-ruby/apis/codecommit/2015-04-13/api-2.json"
 
 mapping "aws_codecommit_approval_rule_template" {
   content = ApprovalRuleTemplateContent

--- a/rules/models/mappings/codedeploy.hcl
+++ b/rules/models/mappings/codedeploy.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/codedeploy/2014-10-06/api-2.json"
+import = "aws-sdk-ruby/apis/codedeploy/2014-10-06/api-2.json"
 
 mapping "aws_codedeploy_app" {
   name             = ApplicationName

--- a/rules/models/mappings/codepipeline.hcl
+++ b/rules/models/mappings/codepipeline.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/codepipeline/2015-07-09/api-2.json"
+import = "aws-sdk-ruby/apis/codepipeline/2015-07-09/api-2.json"
 
 mapping "aws_codepipeline" {
   name     = PipelineName

--- a/rules/models/mappings/codestar-connections.hcl
+++ b/rules/models/mappings/codestar-connections.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/codestar-connections/2019-12-01/api-2.json"
+import = "aws-sdk-ruby/apis/codestar-connections/2019-12-01/api-2.json"
 
 mapping "aws_codestarconnections_connection" {
   name = ConnectionName

--- a/rules/models/mappings/cognito-identity.hcl
+++ b/rules/models/mappings/cognito-identity.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/cognito-identity/2014-06-30/api-2.json"
+import = "aws-sdk-ruby/apis/cognito-identity/2014-06-30/api-2.json"
 
 mapping "aws_cognito_identity_pool" {
   identity_pool_name      = IdentityPoolName

--- a/rules/models/mappings/cognito-idp.hcl
+++ b/rules/models/mappings/cognito-idp.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/cognito-idp/2016-04-18/api-2.json"
+import = "aws-sdk-ruby/apis/cognito-idp/2016-04-18/api-2.json"
 
 mapping "aws_cognito_identity_provider" {
   user_pool_id  = UserPoolIdType

--- a/rules/models/mappings/config.hcl
+++ b/rules/models/mappings/config.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/config/2014-11-12/api-2.json"
+import = "aws-sdk-ruby/apis/config/2014-11-12/api-2.json"
 
 mapping "aws_config_aggregate_authorization" {
   account_id = AccountId

--- a/rules/models/mappings/connect.hcl
+++ b/rules/models/mappings/connect.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/connect/2017-08-08/api-2.json"
+import = "aws-sdk-ruby/apis/connect/2017-08-08/api-2.json"
 
 mapping "aws_connect_bot_association" {
   instance_id = InstanceId

--- a/rules/models/mappings/cur.hcl
+++ b/rules/models/mappings/cur.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/cur/2017-01-06/api-2.json"
+import = "aws-sdk-ruby/apis/cur/2017-01-06/api-2.json"
 
 mapping "aws_cur_report_definition" {
   report_name = ReportName

--- a/rules/models/mappings/datapipeline.hcl
+++ b/rules/models/mappings/datapipeline.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/datapipeline/2012-10-29/api-2.json"
+import = "aws-sdk-ruby/apis/datapipeline/2012-10-29/api-2.json"
 
 mapping "aws_datapipeline_pipeline" {
   name        = any // id

--- a/rules/models/mappings/datasync.hcl
+++ b/rules/models/mappings/datasync.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/datasync/2018-11-09/api-2.json"
+import = "aws-sdk-ruby/apis/datasync/2018-11-09/api-2.json"
 
 mapping "aws_datasync_agent" {
   name           = TagValue

--- a/rules/models/mappings/dax.hcl
+++ b/rules/models/mappings/dax.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/dax/2017-04-19/api-2.json"
+import = "aws-sdk-ruby/apis/dax/2017-04-19/api-2.json"
 
 mapping "aws_dax_cluster" {
   cluster_name           = String

--- a/rules/models/mappings/devicefarm.hcl
+++ b/rules/models/mappings/devicefarm.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/devicefarm/2015-06-23/api-2.json"
+import = "aws-sdk-ruby/apis/devicefarm/2015-06-23/api-2.json"
 
 mapping "aws_devicefarm_device_pool" {
   name = Name

--- a/rules/models/mappings/directconnect.hcl
+++ b/rules/models/mappings/directconnect.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/directconnect/2012-10-25/api-2.json"
+import = "aws-sdk-ruby/apis/directconnect/2012-10-25/api-2.json"
 
 mapping "aws_dx_bgp_peer" {
   address_family       = AddressFamily

--- a/rules/models/mappings/directory-service.hcl
+++ b/rules/models/mappings/directory-service.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ds/2015-04-16/api-2.json"
+import = "aws-sdk-ruby/apis/ds/2015-04-16/api-2.json"
 
 mapping "aws_directory_service_directory" {
   name             = DirectoryName

--- a/rules/models/mappings/dlm.hcl
+++ b/rules/models/mappings/dlm.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/dlm/2018-01-12/api-2.json"
+import = "aws-sdk-ruby/apis/dlm/2018-01-12/api-2.json"
 
 mapping "aws_dlm_lifecycle_policy" {
   description        = PolicyDescription

--- a/rules/models/mappings/dms.hcl
+++ b/rules/models/mappings/dms.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/dms/2016-01-01/api-2.json"
+import = "aws-sdk-ruby/apis/dms/2016-01-01/api-2.json"
 
 mapping "aws_dms_certificate" {
   certificate_id = String

--- a/rules/models/mappings/docdb.hcl
+++ b/rules/models/mappings/docdb.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/docdb/2014-10-31/api-2.json"
+import = "aws-sdk-ruby/apis/docdb/2014-10-31/api-2.json"
 
 mapping "aws_docdb_cluster" {
   apply_immediately               = Boolean

--- a/rules/models/mappings/dynamodb.hcl
+++ b/rules/models/mappings/dynamodb.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/dynamodb/2012-08-10/api-2.json"
+import = "aws-sdk-ruby/apis/dynamodb/2012-08-10/api-2.json"
 
 mapping "aws_dynamodb_global_table" {
   name    = TableName

--- a/rules/models/mappings/ec2.hcl
+++ b/rules/models/mappings/ec2.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ec2/2016-11-15/api-2.json"
+import = "aws-sdk-ruby/apis/ec2/2016-11-15/api-2.json"
 
 mapping "aws_ami" {
   name                   = String

--- a/rules/models/mappings/ecr-public.hcl
+++ b/rules/models/mappings/ecr-public.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ecr-public/2020-10-30/api-2.json"
+import = "aws-sdk-ruby/apis/ecr-public/2020-10-30/api-2.json"
 
 mapping "aws_ecrpublic_repository" {
   repository_name = RepositoryName

--- a/rules/models/mappings/ecr.hcl
+++ b/rules/models/mappings/ecr.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ecr/2015-09-21/api-2.json"
+import = "aws-sdk-ruby/apis/ecr/2015-09-21/api-2.json"
 
 mapping "aws_ecr_lifecycle_policy" {
   repository = RepositoryName

--- a/rules/models/mappings/ecs.hcl
+++ b/rules/models/mappings/ecs.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ecs/2014-11-13/api-2.json"
+import = "aws-sdk-ruby/apis/ecs/2014-11-13/api-2.json"
 
 mapping "aws_ecs_account_setting_default" {
   name = SettingName

--- a/rules/models/mappings/efs.hcl
+++ b/rules/models/mappings/efs.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/elasticfilesystem/2015-02-01/api-2.json"
+import = "aws-sdk-ruby/apis/elasticfilesystem/2015-02-01/api-2.json"
 
 mapping "aws_efs_access_point" {
   file_system_id = FileSystemId

--- a/rules/models/mappings/eks.hcl
+++ b/rules/models/mappings/eks.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/eks/2017-11-01/api-2.json"
+import = "aws-sdk-ruby/apis/eks/2017-11-01/api-2.json"
 
 mapping "aws_eks_addon" {
   cluster_name = ClusterName

--- a/rules/models/mappings/elasticache.hcl
+++ b/rules/models/mappings/elasticache.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/elasticache/2015-02-02/api-2.json"
+import = "aws-sdk-ruby/apis/elasticache/2015-02-02/api-2.json"
 
 mapping "aws_elasticache_cluster" {
   cluster_id                   = String

--- a/rules/models/mappings/elasticbeanstalk.hcl
+++ b/rules/models/mappings/elasticbeanstalk.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/elasticbeanstalk/2010-12-01/api-2.json"
+import = "aws-sdk-ruby/apis/elasticbeanstalk/2010-12-01/api-2.json"
 
 mapping "aws_elastic_beanstalk_application" {
   name        = ApplicationName

--- a/rules/models/mappings/elasticsearch.hcl
+++ b/rules/models/mappings/elasticsearch.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/es/2015-01-01/api-2.json"
+import = "aws-sdk-ruby/apis/es/2015-01-01/api-2.json"
 
 mapping "aws_elasticsearch_domain" {
   domain_name             = DomainName

--- a/rules/models/mappings/elastictranscoder.hcl
+++ b/rules/models/mappings/elastictranscoder.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/elastictranscoder/2012-09-25/api-2.json"
+import = "aws-sdk-ruby/apis/elastictranscoder/2012-09-25/api-2.json"
 
 mapping "aws_elastictranscoder_pipeline" {
   aws_kms_key_arn              = KeyArn

--- a/rules/models/mappings/elb.hcl
+++ b/rules/models/mappings/elb.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/elasticloadbalancing/2012-06-01/api-2.json"
+import = "aws-sdk-ruby/apis/elasticloadbalancing/2012-06-01/api-2.json"
 
 mapping "aws_app_cookie_stickiness_policy" {
   name          = PolicyName

--- a/rules/models/mappings/elbv2.hcl
+++ b/rules/models/mappings/elbv2.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/elasticloadbalancingv2/2015-12-01/api-2.json"
+import = "aws-sdk-ruby/apis/elasticloadbalancingv2/2015-12-01/api-2.json"
 
 mapping "aws_lb" {
   name                             = LoadBalancerName

--- a/rules/models/mappings/emr.hcl
+++ b/rules/models/mappings/emr.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/elasticmapreduce/2009-03-31/api-2.json"
+import = "aws-sdk-ruby/apis/elasticmapreduce/2009-03-31/api-2.json"
 
 mapping "aws_emr_cluster" {
   name                              = String

--- a/rules/models/mappings/fms.hcl
+++ b/rules/models/mappings/fms.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/fms/2018-01-01/api-2.json"
+import = "aws-sdk-ruby/apis/fms/2018-01-01/api-2.json"
 
 mapping "aws_fms_admin_account" {
   account_id = AWSAccountId

--- a/rules/models/mappings/fsx.hcl
+++ b/rules/models/mappings/fsx.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/fsx/2018-03-01/api-2.json"
+import = "aws-sdk-ruby/apis/fsx/2018-03-01/api-2.json"
 
 mapping "aws_fsx_backup" {
   file_system_id = FileSystemId

--- a/rules/models/mappings/gamelift.hcl
+++ b/rules/models/mappings/gamelift.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/gamelift/2015-10-01/api-2.json"
+import = "aws-sdk-ruby/apis/gamelift/2015-10-01/api-2.json"
 
 mapping "aws_gamelift_alias" {
   name             = NonBlankAndLengthConstraintString

--- a/rules/models/mappings/glacier.hcl
+++ b/rules/models/mappings/glacier.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/glacier/2012-06-01/api-2.json"
+import = "aws-sdk-ruby/apis/glacier/2012-06-01/api-2.json"
 
 mapping "aws_glacier_vault" {
   name          = string

--- a/rules/models/mappings/globalaccelerator.hcl
+++ b/rules/models/mappings/globalaccelerator.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/globalaccelerator/2018-08-08/api-2.json"
+import = "aws-sdk-ruby/apis/globalaccelerator/2018-08-08/api-2.json"
 
 mapping "aws_globalaccelerator_accelerator" {
   name            = GenericString

--- a/rules/models/mappings/glue.hcl
+++ b/rules/models/mappings/glue.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/glue/2017-03-31/api-2.json"
+import = "aws-sdk-ruby/apis/glue/2017-03-31/api-2.json"
 
 mapping "aws_glue_catalog_database" {
   name         = any // NameString

--- a/rules/models/mappings/guardduty.hcl
+++ b/rules/models/mappings/guardduty.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/guardduty/2017-11-28/api-2.json"
+import = "aws-sdk-ruby/apis/guardduty/2017-11-28/api-2.json"
 
 mapping "aws_guardduty_detector" {
   enable                       = Boolean

--- a/rules/models/mappings/iam.hcl
+++ b/rules/models/mappings/iam.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/iam/2010-05-08/api-2.json"
+import = "aws-sdk-ruby/apis/iam/2010-05-08/api-2.json"
 
 mapping "aws_iam_access_key" {
   user    = existingUserNameType

--- a/rules/models/mappings/imagebuilder.hcl
+++ b/rules/models/mappings/imagebuilder.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/imagebuilder/2019-12-02/api-2.json"
+import = "aws-sdk-ruby/apis/imagebuilder/2019-12-02/api-2.json"
 
 mapping "aws_imagebuilder_component" {
   name = ResourceName

--- a/rules/models/mappings/inspector.hcl
+++ b/rules/models/mappings/inspector.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/inspector/2016-02-16/api-2.json"
+import = "aws-sdk-ruby/apis/inspector/2016-02-16/api-2.json"
 
 mapping "aws_inspector_assessment_target" {
   name               = AssessmentTargetName

--- a/rules/models/mappings/iot.hcl
+++ b/rules/models/mappings/iot.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/iot/2015-05-28/api-2.json"
+import = "aws-sdk-ruby/apis/iot/2015-05-28/api-2.json"
 
 mapping "aws_iot_certificate" {
   active = SetAsActive

--- a/rules/models/mappings/kinesis-analytics.hcl
+++ b/rules/models/mappings/kinesis-analytics.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/kinesisanalytics/2015-08-14/api-2.json"
+import = "aws-sdk-ruby/apis/kinesisanalytics/2015-08-14/api-2.json"
 
 mapping "aws_kinesis_analytics_application" {
   name                       = ApplicationName

--- a/rules/models/mappings/kinesis-firehose.hcl
+++ b/rules/models/mappings/kinesis-firehose.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/firehose/2015-08-04/api-2.json"
+import = "aws-sdk-ruby/apis/firehose/2015-08-04/api-2.json"
 
 mapping "aws_kinesis_firehose_delivery_stream" {
   name                         = DeliveryStreamName

--- a/rules/models/mappings/kinesis.hcl
+++ b/rules/models/mappings/kinesis.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/kinesis/2013-12-02/api-2.json"
+import = "aws-sdk-ruby/apis/kinesis/2013-12-02/api-2.json"
 
 mapping "aws_kinesis_stream" {
   name                      = StreamName

--- a/rules/models/mappings/kinesisanalyticsv2.hcl
+++ b/rules/models/mappings/kinesisanalyticsv2.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/kinesisanalyticsv2/2018-05-23/api-2.json"
+import = "aws-sdk-ruby/apis/kinesisanalyticsv2/2018-05-23/api-2.json"
 
 mapping "aws_kinesisanalyticsv2_application" {
   name = ApplicationName

--- a/rules/models/mappings/kms.hcl
+++ b/rules/models/mappings/kms.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/kms/2014-11-01/api-2.json"
+import = "aws-sdk-ruby/apis/kms/2014-11-01/api-2.json"
 
 mapping "aws_kms_alias" {
   name          = AliasNameType

--- a/rules/models/mappings/lakeformation.hcl
+++ b/rules/models/mappings/lakeformation.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/lakeformation/2017-03-31/api-2.json"
+import = "aws-sdk-ruby/apis/lakeformation/2017-03-31/api-2.json"
 
 mapping "aws_lakeformation_data_lake_settings" {
   admins = DataLakePrincipalList

--- a/rules/models/mappings/lambda.hcl
+++ b/rules/models/mappings/lambda.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/lambda/2015-03-31/api-2.json"
+import = "aws-sdk-ruby/apis/lambda/2015-03-31/api-2.json"
 
 mapping "aws_lambda_alias" {
   name             = any // Alias

--- a/rules/models/mappings/launch-configuration.hcl
+++ b/rules/models/mappings/launch-configuration.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ec2/2016-11-15/api-2.json"
+import = "aws-sdk-ruby/apis/ec2/2016-11-15/api-2.json"
 
 // NOTE: `aws_launch_configuration` mapping is already defined in autoscaling.hcl
 //       The following mapping is to import ec2 types.

--- a/rules/models/mappings/license-manager.hcl
+++ b/rules/models/mappings/license-manager.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/license-manager/2018-08-01/api-2.json"
+import = "aws-sdk-ruby/apis/license-manager/2018-08-01/api-2.json"
 
 mapping "aws_licensemanager_association" {
   license_configuration_arn = String

--- a/rules/models/mappings/lightsail.hcl
+++ b/rules/models/mappings/lightsail.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/lightsail/2016-11-28/api-2.json"
+import = "aws-sdk-ruby/apis/lightsail/2016-11-28/api-2.json"
 
 mapping "aws_lightsail_domain" {
   domain_name = DomainName

--- a/rules/models/mappings/macie2.hcl
+++ b/rules/models/mappings/macie2.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/macie2/2020-01-01/api-2.json"
+import = "aws-sdk-ruby/apis/macie2/2020-01-01/api-2.json"
 
 mapping "aws_macie2_account" {
   finding_publishing_frequency = FindingPublishingFrequency

--- a/rules/models/mappings/mediapackage.hcl
+++ b/rules/models/mappings/mediapackage.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/mediapackage/2017-10-12/api-2.json"
+import = "aws-sdk-ruby/apis/mediapackage/2017-10-12/api-2.json"
 
 mapping "aws_media_package_channel" {
   channel_id  = __string

--- a/rules/models/mappings/mediastore.hcl
+++ b/rules/models/mappings/mediastore.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/mediastore/2017-09-01/api-2.json"
+import = "aws-sdk-ruby/apis/mediastore/2017-09-01/api-2.json"
 
 mapping "aws_media_store_container" {
   name = ContainerName

--- a/rules/models/mappings/memorydb.hcl
+++ b/rules/models/mappings/memorydb.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/memorydb/2021-01-01/api-2.json"
+import = "aws-sdk-ruby/apis/memorydb/2021-01-01/api-2.json"
 
 mapping "aws_memorydb_acl" {
   user_names = UserNameListInput

--- a/rules/models/mappings/mq.hcl
+++ b/rules/models/mappings/mq.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/mq/2017-11-27/api-2.json"
+import = "aws-sdk-ruby/apis/mq/2017-11-27/api-2.json"
 
 mapping "aws_mq_broker" {
   apply_immediately             = any

--- a/rules/models/mappings/msk.hcl
+++ b/rules/models/mappings/msk.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/kafka/2018-11-14/api-2.json"
+import = "aws-sdk-ruby/apis/kafka/2018-11-14/api-2.json"
 
 mapping "aws_msk_cluster" {
   broker_node_group_info = BrokerNodeGroupInfo

--- a/rules/models/mappings/neptune.hcl
+++ b/rules/models/mappings/neptune.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/neptune/2014-10-31/api-2.json"
+import = "aws-sdk-ruby/apis/neptune/2014-10-31/api-2.json"
 
 mapping "aws_neptune_parameter_group" {
   name        = String

--- a/rules/models/mappings/network-firewall.hcl
+++ b/rules/models/mappings/network-firewall.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/network-firewall/2020-11-12/api-2.json"
+import = "aws-sdk-ruby/apis/network-firewall/2020-11-12/api-2.json"
 
 mapping "aws_networkfirewall_firewall" {
   description = Description

--- a/rules/models/mappings/opsworks.hcl
+++ b/rules/models/mappings/opsworks.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/opsworks/2013-02-18/api-2.json"
+import = "aws-sdk-ruby/apis/opsworks/2013-02-18/api-2.json"
 
 mapping "aws_opsworks_application" {
   name                      = String

--- a/rules/models/mappings/organizations.hcl
+++ b/rules/models/mappings/organizations.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/organizations/2016-11-28/api-2.json"
+import = "aws-sdk-ruby/apis/organizations/2016-11-28/api-2.json"
 
 mapping "aws_organizations_account" {
   name                       = AccountName

--- a/rules/models/mappings/pinpoint.hcl
+++ b/rules/models/mappings/pinpoint.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/pinpoint/2016-12-01/api-2.json"
+import = "aws-sdk-ruby/apis/pinpoint/2016-12-01/api-2.json"
 
 mapping "aws_pinpoint_app" {
   name          = __string

--- a/rules/models/mappings/prometheus.hcl
+++ b/rules/models/mappings/prometheus.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/amp/2020-08-01/api-2.json"
+import = "aws-sdk-ruby/apis/amp/2020-08-01/api-2.json"
 
 mapping "aws_prometheus_alert_manager_definition" {
   workspace_id = WorkspaceId

--- a/rules/models/mappings/quicksight.hcl
+++ b/rules/models/mappings/quicksight.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/quicksight/2018-04-01/api-2.json"
+import = "aws-sdk-ruby/apis/quicksight/2018-04-01/api-2.json"
 
 mapping "aws_quicksight_data_source" {
   data_source_id = ResourceId

--- a/rules/models/mappings/ram.hcl
+++ b/rules/models/mappings/ram.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ram/2018-01-04/api-2.json"
+import = "aws-sdk-ruby/apis/ram/2018-01-04/api-2.json"
 
 mapping "aws_ram_principal_association" {
   principal          = String

--- a/rules/models/mappings/rds.hcl
+++ b/rules/models/mappings/rds.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/rds/2014-10-31/api-2.json"
+import = "aws-sdk-ruby/apis/rds/2014-10-31/api-2.json"
 
 mapping "aws_db_cluster_snapshot" {
   db_cluster_identifier          = String

--- a/rules/models/mappings/redshift.hcl
+++ b/rules/models/mappings/redshift.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/redshift/2012-12-01/api-2.json"
+import = "aws-sdk-ruby/apis/redshift/2012-12-01/api-2.json"
 
 mapping "aws_redshift_cluster" {
   cluster_identifier                  = String

--- a/rules/models/mappings/resource-groups.hcl
+++ b/rules/models/mappings/resource-groups.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/resource-groups/2017-11-27/api-2.json"
+import = "aws-sdk-ruby/apis/resource-groups/2017-11-27/api-2.json"
 
 mapping "aws_resourcegroups_group" {
   name           = GroupName

--- a/rules/models/mappings/route53-recovery-control-config.hcl
+++ b/rules/models/mappings/route53-recovery-control-config.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/route53-recovery-control-config/2020-11-02/api-2.json"
+import = "aws-sdk-ruby/apis/route53-recovery-control-config/2020-11-02/api-2.json"
 
 mapping "aws_route53recoverycontrolconfig_cluster" {
   name = __stringMin1Max64PatternS

--- a/rules/models/mappings/route53-recovery-readiness.hcl
+++ b/rules/models/mappings/route53-recovery-readiness.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/route53-recovery-readiness/2019-12-02/api-2.json"
+import = "aws-sdk-ruby/apis/route53-recovery-readiness/2019-12-02/api-2.json"
 
 mapping "aws_route53recoveryreadiness_cell" {
   tags = Tags

--- a/rules/models/mappings/route53-resolver.hcl
+++ b/rules/models/mappings/route53-resolver.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/route53resolver/2018-04-01/api-2.json"
+import = "aws-sdk-ruby/apis/route53resolver/2018-04-01/api-2.json"
 
 mapping "aws_route53_resolver_dnssec_config" {
   resource_id = ResourceId

--- a/rules/models/mappings/route53.hcl
+++ b/rules/models/mappings/route53.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/route53/2013-04-01/api-2.json"
+import = "aws-sdk-ruby/apis/route53/2013-04-01/api-2.json"
 
 mapping "aws_route53_delegation_set" {
   reference_name = Nonce

--- a/rules/models/mappings/s3.hcl
+++ b/rules/models/mappings/s3.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/s3/2006-03-01/api-2.json"
+import = "aws-sdk-ruby/apis/s3/2006-03-01/api-2.json"
 
 mapping "aws_s3_account_public_access_block" {
   account_id              = AccountId

--- a/rules/models/mappings/s3control.hcl
+++ b/rules/models/mappings/s3control.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/s3control/2018-08-20/api-2.json"
+import = "aws-sdk-ruby/apis/s3control/2018-08-20/api-2.json"
 
 mapping "aws_s3control_access_point_policy" {
   access_point_arn = S3AccessPointArn

--- a/rules/models/mappings/sagemaker.hcl
+++ b/rules/models/mappings/sagemaker.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/sagemaker/2017-07-24/api-2.json"
+import = "aws-sdk-ruby/apis/sagemaker/2017-07-24/api-2.json"
 
 mapping "aws_sagemaker_app" {
   app_name = AppName

--- a/rules/models/mappings/schemas.hcl
+++ b/rules/models/mappings/schemas.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/schemas/2019-12-02/api-2.json"
+import = "aws-sdk-ruby/apis/schemas/2019-12-02/api-2.json"
 
 mapping "aws_schemas_discoverer" {
   source_arn = __stringMin20Max1600

--- a/rules/models/mappings/secretsmanager.hcl
+++ b/rules/models/mappings/secretsmanager.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/secretsmanager/2017-10-17/api-2.json"
+import = "aws-sdk-ruby/apis/secretsmanager/2017-10-17/api-2.json"
 
 mapping "aws_secretsmanager_secret" {
   name                    = NameType

--- a/rules/models/mappings/securityhub.hcl
+++ b/rules/models/mappings/securityhub.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/securityhub/2018-10-26/api-2.json"
+import = "aws-sdk-ruby/apis/securityhub/2018-10-26/api-2.json"
 
 mapping "aws_securityhub_account" {}
 

--- a/rules/models/mappings/service-discovery.hcl
+++ b/rules/models/mappings/service-discovery.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/servicediscovery/2017-03-14/api-2.json"
+import = "aws-sdk-ruby/apis/servicediscovery/2017-03-14/api-2.json"
 
 mapping "aws_service_discovery_http_namespace" {
   name        = NamespaceName

--- a/rules/models/mappings/service-quotas.hcl
+++ b/rules/models/mappings/service-quotas.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/service-quotas/2019-06-24/api-2.json"
+import = "aws-sdk-ruby/apis/service-quotas/2019-06-24/api-2.json"
 
 mapping "aws_servicequotas_service_quota" {
   quota_code   = QuotaCode

--- a/rules/models/mappings/servicecatalog.hcl
+++ b/rules/models/mappings/servicecatalog.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/servicecatalog/2015-12-10/api-2.json"
+import = "aws-sdk-ruby/apis/servicecatalog/2015-12-10/api-2.json"
 
 mapping "aws_servicecatalog_budget_resource_association" {
   budget_name = BudgetName

--- a/rules/models/mappings/ses.hcl
+++ b/rules/models/mappings/ses.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/email/2010-12-01/api-2.json"
+import = "aws-sdk-ruby/apis/email/2010-12-01/api-2.json"
 
 mapping "aws_ses_active_receipt_rule_set" {
   rule_set_name = ReceiptRuleSetName

--- a/rules/models/mappings/sfn.hcl
+++ b/rules/models/mappings/sfn.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/states/2016-11-23/api-2.json"
+import = "aws-sdk-ruby/apis/states/2016-11-23/api-2.json"
 
 mapping "aws_sfn_activity" {
   name = Name

--- a/rules/models/mappings/shield.hcl
+++ b/rules/models/mappings/shield.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/shield/2016-06-02/api-2.json"
+import = "aws-sdk-ruby/apis/shield/2016-06-02/api-2.json"
 
 mapping "aws_shield_protection" {
   name         = ProtectionName

--- a/rules/models/mappings/signer.hcl
+++ b/rules/models/mappings/signer.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/signer/2017-08-25/api-2.json"
+import = "aws-sdk-ruby/apis/signer/2017-08-25/api-2.json"
 
 mapping "aws_signer_signing_job" {
   profile_name = ProfileName

--- a/rules/models/mappings/simpledb.hcl
+++ b/rules/models/mappings/simpledb.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/sdb/2009-04-15/api-2.json"
+import = "aws-sdk-ruby/apis/sdb/2009-04-15/api-2.json"
 
 mapping "aws_simpledb_domain" {
   name = String

--- a/rules/models/mappings/sns.hcl
+++ b/rules/models/mappings/sns.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/sns/2010-03-31/api-2.json"
+import = "aws-sdk-ruby/apis/sns/2010-03-31/api-2.json"
 
 mapping "aws_sns_platform_application" {
   name                             = String

--- a/rules/models/mappings/sqs.hcl
+++ b/rules/models/mappings/sqs.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/sqs/2012-11-05/api-2.json"
+import = "aws-sdk-ruby/apis/sqs/2012-11-05/api-2.json"
 
 mapping "aws_sqs_queue" {
   name                              = String

--- a/rules/models/mappings/ssm.hcl
+++ b/rules/models/mappings/ssm.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ssm/2014-11-06/api-2.json"
+import = "aws-sdk-ruby/apis/ssm/2014-11-06/api-2.json"
 
 mapping "aws_ssm_activation" {
   name               = DefaultInstanceName

--- a/rules/models/mappings/sso-admin.hcl
+++ b/rules/models/mappings/sso-admin.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/sso-admin/2020-07-20/api-2.json"
+import = "aws-sdk-ruby/apis/sso-admin/2020-07-20/api-2.json"
 
 mapping "aws_ssoadmin_account_assignment" {
   instance_arn = InstanceArn

--- a/rules/models/mappings/storagegateway.hcl
+++ b/rules/models/mappings/storagegateway.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/storagegateway/2013-06-30/api-2.json"
+import = "aws-sdk-ruby/apis/storagegateway/2013-06-30/api-2.json"
 
 mapping "aws_storagegateway_cache" {
   disk_id     = DiskId

--- a/rules/models/mappings/swf.hcl
+++ b/rules/models/mappings/swf.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/swf/2012-01-25/api-2.json"
+import = "aws-sdk-ruby/apis/swf/2012-01-25/api-2.json"
 
 mapping "aws_swf_domain" {
   name                                        = DomainName

--- a/rules/models/mappings/timestream-write.hcl
+++ b/rules/models/mappings/timestream-write.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/timestream-write/2018-11-01/api-2.json"
+import = "aws-sdk-ruby/apis/timestream-write/2018-11-01/api-2.json"
 
 mapping "aws_timestreamwrite_database" {
   database_name = ResourceCreateAPIName

--- a/rules/models/mappings/transfer.hcl
+++ b/rules/models/mappings/transfer.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/transfer/2018-11-05/api-2.json"
+import = "aws-sdk-ruby/apis/transfer/2018-11-05/api-2.json"
 
 mapping "aws_transfer_access" {
   external_id = ExternalId

--- a/rules/models/mappings/vpc.hcl
+++ b/rules/models/mappings/vpc.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/ec2/2016-11-15/api-2.json"
+import = "aws-sdk-ruby/apis/ec2/2016-11-15/api-2.json"
 
 mapping "aws_customer_gateway" {
   bgp_asn    = Integer

--- a/rules/models/mappings/waf-regional.hcl
+++ b/rules/models/mappings/waf-regional.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/waf-regional/2016-11-28/api-2.json"
+import = "aws-sdk-ruby/apis/waf-regional/2016-11-28/api-2.json"
 
 mapping "aws_wafregional_byte_match_set" {
   name              = ResourceName

--- a/rules/models/mappings/waf.hcl
+++ b/rules/models/mappings/waf.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/waf/2015-08-24/api-2.json"
+import = "aws-sdk-ruby/apis/waf/2015-08-24/api-2.json"
 
 mapping "aws_waf_byte_match_set" {
   name              = ResourceName

--- a/rules/models/mappings/wafv2.hcl
+++ b/rules/models/mappings/wafv2.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/wafv2/2019-07-29/api-2.json"
+import = "aws-sdk-ruby/apis/wafv2/2019-07-29/api-2.json"
 
 mapping "aws_wafv2_ip_set" {
   name = EntityName

--- a/rules/models/mappings/worklink.hcl
+++ b/rules/models/mappings/worklink.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/worklink/2018-09-25/api-2.json"
+import = "aws-sdk-ruby/apis/worklink/2018-09-25/api-2.json"
 
 mapping "aws_worklink_fleet" {
   name                           = FleetName

--- a/rules/models/mappings/workspaces.hcl
+++ b/rules/models/mappings/workspaces.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/workspaces/2015-04-08/api-2.json"
+import = "aws-sdk-ruby/apis/workspaces/2015-04-08/api-2.json"
 
 mapping "aws_workspaces_directory" {
   directory_id = DirectoryId

--- a/rules/models/mappings/xray.hcl
+++ b/rules/models/mappings/xray.hcl
@@ -1,4 +1,4 @@
-import = "aws-sdk-go/models/apis/xray/2016-04-12/api-2.json"
+import = "aws-sdk-ruby/apis/xray/2016-04-12/api-2.json"
 
 mapping "aws_xray_encryption_config" {
   type = EncryptionType


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-aws/issues/611

Because aws-sdk-go ended its support on July 31, we will need to migrate API specs that referenced in mapping files.

Initially, I considered migrating the submodule aws-sdk-go to v2, but v2 uses Smithy instead of OpenAPI, so we would need to significantly rewrite the generator. After some more digging, I noticed that [aws-sdk-ruby](https://github.com/aws/aws-sdk-ruby) includes the non-deprecated OpenAPI specification, and this PR changes the import path to reference this.

This change may not be a fundamental solution, as similar changes may occur in future versions of aws-sdk-ruby. Ideally, a maintained OpenAPI specification would be published, but I could not find one as far as I could find. In some cases, we may need to migrate to a Smithy-based solution.