### PR TITLE
Fix incorrect mapping about aws_servicecatalog_portfolio_share type

### DIFF
--- a/rules/models/aws_servicecatalog_portfolio_share_invalid_type.go
+++ b/rules/models/aws_servicecatalog_portfolio_share_invalid_type.go
@@ -25,9 +25,10 @@ func NewAwsServicecatalogPortfolioShareInvalidTypeRule() *AwsServicecatalogPortf
 		resourceType:  "aws_servicecatalog_portfolio_share",
 		attributeName: "type",
 		enum: []string{
-			"IMPORTED",
-			"AWS_SERVICECATALOG",
-			"AWS_ORGANIZATIONS",
+			"ACCOUNT",
+			"ORGANIZATION",
+			"ORGANIZATIONAL_UNIT",
+			"ORGANIZATION_MEMBER_ACCOUNT",
 		},
 	}
 }

--- a/rules/models/mappings/servicecatalog.hcl
+++ b/rules/models/mappings/servicecatalog.hcl
@@ -24,7 +24,7 @@ mapping "aws_servicecatalog_portfolio" {
 mapping "aws_servicecatalog_portfolio_share" {
   portfolio_id = Id
   principal_id = Id
-  type = PortfolioShareType
+  type = DescribePortfolioShareType
   accept_language = AcceptLanguage
 }
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-aws/issues/711

Based on the available enum values, the shape that corresponds to `aws_servicecatalog_portfolio_share` type is `DescribePortfolioShareType`, not `PortfolioShareType`.