### PR TITLE
Remove patch version pin from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint-ruleset-aws
 
-go 1.23.1
+go 1.23
 
 require (
 	github.com/agext/levenshtein v1.2.2 // indirect


### PR DESCRIPTION
At one point in the past, the `go` command would not work properly unless you pinned the patch version, but that no longer seems to be the case.