### PR TITLE
feat: add aws_security_group_rule_deprecated rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -52,6 +52,7 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_s3_bucket_invalid_region|Disallow invalid region for S3 bucket||✔|
 |aws_spot_fleet_request_invalid_excess_capacity_termination_policy|Disallow invalid excess capacity termination policy||✔|
 |[aws_security_group_invalid_protocol](aws_security_group_invalid_protocol.md)|Disallow using invalid protocol||✔|
+|[aws_security_group_rule_deprecated](aws_security_group_rule_deprecated.md)|Disallow using `aws_security_group_rule` resource|||
 |[aws_security_group_rule_invalid_protocol](aws_security_group_rule_invalid_protocol.md)|Disallow using invalid protocol||✔|
 
 ### Best Practices/Naming Conventions

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -72,10 +72,10 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)|Disallow deprecated runtimes for Lambda Function|✔|
-|[aws_provider_missing_default_tags](aws_provider_missing_default_tags.md)|Require specific tags for all AWS providers default tags||
 |[aws_resource_missing_tags](aws_resource_missing_tags.md)|Require specific tags for all AWS resource types that support them||
 |[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the naming rules|✔|
 |[aws_security_group_rule_deprecated](aws_security_group_rule_deprecated.md)|Disallow using `aws_security_group_rule` resource||
+|[aws_provider_missing_default_tags](aws_provider_missing_default_tags.md)|Require specific tags for all AWS providers default tags||
 
 ### SDK-based Validations
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -52,7 +52,6 @@ These rules warn of possible errors that can occur at `terraform apply`. Rules m
 |aws_s3_bucket_invalid_region|Disallow invalid region for S3 bucket||✔|
 |aws_spot_fleet_request_invalid_excess_capacity_termination_policy|Disallow invalid excess capacity termination policy||✔|
 |[aws_security_group_invalid_protocol](aws_security_group_invalid_protocol.md)|Disallow using invalid protocol||✔|
-|[aws_security_group_rule_deprecated](aws_security_group_rule_deprecated.md)|Disallow using `aws_security_group_rule` resource|||
 |[aws_security_group_rule_invalid_protocol](aws_security_group_rule_invalid_protocol.md)|Disallow using invalid protocol||✔|
 
 ### Best Practices/Naming Conventions
@@ -73,9 +72,10 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)|Disallow deprecated runtimes for Lambda Function|✔|
+|[aws_provider_missing_default_tags](aws_provider_missing_default_tags.md)|Require specific tags for all AWS providers default tags||
 |[aws_resource_missing_tags](aws_resource_missing_tags.md)|Require specific tags for all AWS resource types that support them||
 |[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the naming rules|✔|
-|[aws_provider_missing_default_tags](aws_provider_missing_default_tags.md)|Require specific tags for all AWS providers default tags||
+|[aws_security_group_rule_deprecated](aws_security_group_rule_deprecated.md)|Disallow using `aws_security_group_rule` resource||
 
 ### SDK-based Validations
 

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -74,6 +74,7 @@ These rules enforce best practices and naming conventions:
 |[aws_lambda_function_deprecated_runtime](aws_lambda_function_deprecated_runtime.md)|Disallow deprecated runtimes for Lambda Function|✔|
 |[aws_resource_missing_tags](aws_resource_missing_tags.md)|Require specific tags for all AWS resource types that support them||
 |[aws_s3_bucket_name](aws_s3_bucket_name.md)|Ensures all S3 bucket names match the naming rules|✔|
+|[aws_security_group_rule_deprecated](aws_security_group_rule_deprecated.md)|Disallow using `aws_security_group_rule` resource||
 |[aws_provider_missing_default_tags](aws_provider_missing_default_tags.md)|Require specific tags for all AWS providers default tags||
 
 ### SDK-based Validations

--- a/docs/rules/aws_security_group_rule_deprecated.md
+++ b/docs/rules/aws_security_group_rule_deprecated.md
@@ -14,13 +14,12 @@ resource "aws_security_group_rule" "foo" {
 ❯ tflint
 1 issue(s) found:
 
-Warning: Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_group_ingress_rule instead.
+Warning: Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_group_ingress_rule instead. (aws_security_group_rule_deprecated)
 
-  on test.tf line 5:
+  on bastion.tf line 4:
    4:   resource "aws_security_group_rule" "foo" {
-   5:     security_group_id = "sg-12345678"
-   6:   }
 ```
+
 ## Why
 
 Avoid using the `aws_security_group_rule` resource, as it struggles with managing multiple CIDR blocks, and, due to the historical lack of unique IDs, tags and descriptions.

--- a/docs/rules/aws_security_group_rule_deprecated.md
+++ b/docs/rules/aws_security_group_rule_deprecated.md
@@ -1,0 +1,26 @@
+# aws_security_group_rule_deprecated
+
+// TODO: Write the rule's description here
+
+## Example
+
+```hcl
+resource "null_resource" "foo" {
+  // TODO: Write the example Terraform code which violates the rule
+}
+```
+
+```
+$ tflint
+
+// TODO: Write the output when inspects the above code
+
+```
+
+## Why
+
+// TODO: Write why you should follow the rule. This section is also a place to explain the value of the rule
+
+## How To Fix
+
+// TODO: Write how to fix it to avoid the problem

--- a/docs/rules/aws_security_group_rule_deprecated.md
+++ b/docs/rules/aws_security_group_rule_deprecated.md
@@ -1,12 +1,13 @@
 # aws_security_group_rule_deprecated
 
-// TODO: Write the rule's description here
+The `aws_security_group_rule` resource should be replaced with `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule`. It lacks support of unique IDs, tags, and descriptions, and has difficulties managing multiple CIDR blocks.
 
 ## Example
 
 ```hcl
 resource "aws_security_group_rule" "foo" {
   security_group_id = "sg-12345678"
+  type              = "ingress"
 }
 ```
 
@@ -22,9 +23,7 @@ Warning: Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_g
 
 ## Why
 
-Avoid using the `aws_security_group_rule` resource, as it struggles with managing multiple CIDR blocks, and, due to the historical lack of unique IDs, tags and descriptions.
-
-For further information, see the [Terraform documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule).
+Avoid using the [`aws_security_group_rule`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) resource because it has difficulties managing multiple CIDR blocks and historically lacks unique IDs, tags, and descriptions. To prevent these issues, follow the current best practice of using the `aws_vpc_security_group_egress_rule` and `aws_vpc_security_group_ingress_rule` resources.
 
 ## How To Fix
 

--- a/docs/rules/aws_security_group_rule_deprecated.md
+++ b/docs/rules/aws_security_group_rule_deprecated.md
@@ -28,4 +28,4 @@ For further information, see the [Terraform documentation](https://registry.terr
 
 ## How To Fix
 
-Depending on `foo.type`, you can fix the issue by using either `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule`.
+Depending on `type`, you can fix the issue by using either `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule`.

--- a/docs/rules/aws_security_group_rule_deprecated.md
+++ b/docs/rules/aws_security_group_rule_deprecated.md
@@ -25,6 +25,8 @@ Warning: Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_g
 
 Avoid using the `aws_security_group_rule` resource, as it struggles with managing multiple CIDR blocks, and, due to the historical lack of unique IDs, tags and descriptions.
 
+For further information, see the [Terraform documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule).
+
 ## How To Fix
 
-Depending on `foo.type`, you can fix the issue by using either `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule`:
+Depending on `foo.type`, you can fix the issue by using either `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule`.

--- a/docs/rules/aws_security_group_rule_deprecated.md
+++ b/docs/rules/aws_security_group_rule_deprecated.md
@@ -5,22 +5,26 @@
 ## Example
 
 ```hcl
-resource "null_resource" "foo" {
-  // TODO: Write the example Terraform code which violates the rule
+resource "aws_security_group_rule" "foo" {
+  security_group_id = "sg-12345678"
 }
 ```
 
+```sh
+❯ tflint
+1 issue(s) found:
+
+Warning: Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_group_ingress_rule instead.
+
+  on test.tf line 5:
+   4:   resource "aws_security_group_rule" "foo" {
+   5:     security_group_id = "sg-12345678"
+   6:   }
 ```
-$ tflint
-
-// TODO: Write the output when inspects the above code
-
-```
-
 ## Why
 
-// TODO: Write why you should follow the rule. This section is also a place to explain the value of the rule
+Avoid using the `aws_security_group_rule` resource, as it struggles with managing multiple CIDR blocks, and, due to the historical lack of unique IDs, tags and descriptions.
 
 ## How To Fix
 
-// TODO: Write how to fix it to avoid the problem
+Depending on `foo.type`, you can fix the issue by using either `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule`:

--- a/rules/aws_security_group_rule_deprecated.go
+++ b/rules/aws_security_group_rule_deprecated.go
@@ -1,0 +1,79 @@
+package rules
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// TODO: Write the rule's description here
+// AwsSecurityGroupRuleDeprecatedRule checks ...
+type AwsSecurityGroupRuleDeprecatedRule struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsSecurityGroupRuleDeprecatedRule returns new rule with default attributes
+func NewAwsSecurityGroupRuleDeprecatedRule() *AwsSecurityGroupRuleDeprecatedRule {
+	return &AwsSecurityGroupRuleDeprecatedRule{
+		// TODO: Write resource type and attribute name here
+		resourceType:  "...",
+		attributeName: "...",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsSecurityGroupRuleDeprecatedRule) Name() string {
+	return "aws_security_group_rule_deprecated"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsSecurityGroupRuleDeprecatedRule) Enabled() bool {
+	// TODO: Determine whether the rule is enabled by default
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsSecurityGroupRuleDeprecatedRule) Severity() tflint.Severity {
+	// TODO: Determine the rule's severiry
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsSecurityGroupRuleDeprecatedRule) Link() string {
+	// TODO: If the rule is so trivial that no documentation is needed, return "" instead.
+	return project.ReferenceLink(r.Name())
+}
+
+// TODO: Write the details of the inspection
+// Check checks ...
+func (r *AwsSecurityGroupRuleDeprecatedRule) Check(runner tflint.Runner) error {
+	// TODO: Write the implementation here. See this documentation for what tflint.Runner can do.
+	//       https://pkg.go.dev/github.com/terraform-linters/tflint-plugin-sdk/tflint#Runner
+
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{
+			{Name: r.attributeName},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		runner.EmitIssue(
+			r,
+			"Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_group_ingress_rule instead.",
+			attribute.Expr.Range(),
+		)
+	}
+
+	return nil
+}

--- a/rules/aws_security_group_rule_deprecated.go
+++ b/rules/aws_security_group_rule_deprecated.go
@@ -44,11 +44,7 @@ func (r *AwsSecurityGroupRuleDeprecatedRule) Link() string {
 
 // Check that aws_security_group_rule resource is not used
 func (r *AwsSecurityGroupRuleDeprecatedRule) Check(runner tflint.Runner) error {
-	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
-		Attributes: []hclext.AttributeSchema{
-			{Name: r.attributeName},
-		},
-	}, nil)
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{}, nil)
 	if err != nil {
 		return err
 	}

--- a/rules/aws_security_group_rule_deprecated.go
+++ b/rules/aws_security_group_rule_deprecated.go
@@ -54,15 +54,10 @@ func (r *AwsSecurityGroupRuleDeprecatedRule) Check(runner tflint.Runner) error {
 	}
 
 	for _, resource := range resources.Blocks {
-		attribute, exists := resource.Body.Attributes[r.attributeName]
-		if !exists {
-			continue
-		}
-
 		runner.EmitIssue(
 			r,
 			"Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_group_ingress_rule instead.",
-			attribute.Expr.Range(),
+			resource.DefRange,
 		)
 	}
 

--- a/rules/aws_security_group_rule_deprecated.go
+++ b/rules/aws_security_group_rule_deprecated.go
@@ -6,8 +6,7 @@ import (
 	"github.com/terraform-linters/tflint-ruleset-aws/project"
 )
 
-// TODO: Write the rule's description here
-// AwsSecurityGroupRuleDeprecatedRule checks ...
+// AwsSecurityGroupRuleDeprecatedRule checks that aws_security_group_rule is not used
 type AwsSecurityGroupRuleDeprecatedRule struct {
 	tflint.DefaultRule
 
@@ -18,9 +17,8 @@ type AwsSecurityGroupRuleDeprecatedRule struct {
 // NewAwsSecurityGroupRuleDeprecatedRule returns new rule with default attributes
 func NewAwsSecurityGroupRuleDeprecatedRule() *AwsSecurityGroupRuleDeprecatedRule {
 	return &AwsSecurityGroupRuleDeprecatedRule{
-		// TODO: Write resource type and attribute name here
-		resourceType:  "...",
-		attributeName: "...",
+		resourceType:  "aws_security_group_rule",
+		attributeName: "security_group_id",
 	}
 }
 
@@ -31,28 +29,21 @@ func (r *AwsSecurityGroupRuleDeprecatedRule) Name() string {
 
 // Enabled returns whether the rule is enabled by default
 func (r *AwsSecurityGroupRuleDeprecatedRule) Enabled() bool {
-	// TODO: Determine whether the rule is enabled by default
-	return true
+	return false
 }
 
 // Severity returns the rule severity
 func (r *AwsSecurityGroupRuleDeprecatedRule) Severity() tflint.Severity {
-	// TODO: Determine the rule's severiry
-	return tflint.ERROR
+	return tflint.WARNING
 }
 
 // Link returns the rule reference link
 func (r *AwsSecurityGroupRuleDeprecatedRule) Link() string {
-	// TODO: If the rule is so trivial that no documentation is needed, return "" instead.
 	return project.ReferenceLink(r.Name())
 }
 
-// TODO: Write the details of the inspection
-// Check checks ...
+// Check that aws_security_group_rule resource is not used
 func (r *AwsSecurityGroupRuleDeprecatedRule) Check(runner tflint.Runner) error {
-	// TODO: Write the implementation here. See this documentation for what tflint.Runner can do.
-	//       https://pkg.go.dev/github.com/terraform-linters/tflint-plugin-sdk/tflint#Runner
-
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
 		Attributes: []hclext.AttributeSchema{
 			{Name: r.attributeName},

--- a/rules/aws_security_group_rule_deprecated_test.go
+++ b/rules/aws_security_group_rule_deprecated_test.go
@@ -14,22 +14,32 @@ func Test_AwsSecurityGroupRuleDeprecated(t *testing.T) {
 		Expected helper.Issues
 	}{
 		{
-			Name: "basic",
+			Name: "resource is used",
 			Content: `
-resource "null_resource" "null" {
+resource "aws_security_group_rule" "test" {
+	security_group_id = "sg-12345678"
 }
 `,
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsSecurityGroupRuleDeprecatedRule(),
-					Message: "TODO",
+					Message: "Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_group_ingress_rule instead.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
-						Start:    hcl.Pos{Line: 0, Column: 0},
-						End:      hcl.Pos{Line: 0, Column: 0},
+						Start:    hcl.Pos{Line: 3, Column: 22},
+						End:      hcl.Pos{Line: 3, Column: 35},
 					},
 				},
 			},
+		},
+		{
+			Name: "everything is fine",
+			Content: `
+resource "aws_security_group" "test" {
+	name = "test"
+}
+`,
+			Expected: helper.Issues{},
 		},
 	}
 

--- a/rules/aws_security_group_rule_deprecated_test.go
+++ b/rules/aws_security_group_rule_deprecated_test.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsSecurityGroupRuleDeprecated(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "basic",
+			Content: `
+resource "null_resource" "null" {
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsSecurityGroupRuleDeprecatedRule(),
+					Message: "TODO",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 0, Column: 0},
+						End:      hcl.Pos{Line: 0, Column: 0},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewAwsSecurityGroupRuleDeprecatedRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_security_group_rule_deprecated_test.go
+++ b/rules/aws_security_group_rule_deprecated_test.go
@@ -26,8 +26,8 @@ resource "aws_security_group_rule" "test" {
 					Message: "Consider using aws_vpc_security_group_egress_rule or aws_vpc_security_group_ingress_rule instead.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
-						Start:    hcl.Pos{Line: 3, Column: 22},
-						End:      hcl.Pos{Line: 3, Column: 35},
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 42},
 					},
 				},
 			},

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -40,6 +40,7 @@ var manualRules = []tflint.Rule{
 	NewAwsSecurityGroupInvalidProtocolRule(),
 	NewAwsSecurityGroupRuleInvalidProtocolRule(),
 	NewAwsProviderMissingDefaultTagsRule(),
+	NewAwsSecurityGroupRuleDeprecatedRule(),
 }
 
 // Rules is a list of all rules


### PR DESCRIPTION
Adds a rule which generates a warning if a `aws_security_group_rule` is used. According to the docs the `aws_vpc_security_group_egress_rule` or `aws_vpc_security_group_ingress_rule` should be used.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule