### PR TITLE
Remove hard-coded versions from integration tests

### DIFF
--- a/integration/cty-based-eval/result.json.tmpl
+++ b/integration/cty-based-eval/result.json.tmpl
@@ -4,18 +4,18 @@
       "rule": {
         "name": "aws_resource_missing_tags",
         "severity": "info",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.37.0/docs/rules/aws_resource_missing_tags.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v{{.Version}}/docs/rules/aws_resource_missing_tags.md"
       },
       "message": "The resource is missing the following tags: \"Environment\", \"Name\", \"Type\".",
       "range": {
         "filename": "template.tf",
         "start": {
-          "line": 2,
-          "column": 10
+          "line": 5,
+          "column": 1
         },
         "end": {
-          "line": 2,
-          "column": 25
+          "line": 5,
+          "column": 41
         }
       },
       "callers": []

--- a/integration/map-attribute/result.json.tmpl
+++ b/integration/map-attribute/result.json.tmpl
@@ -4,18 +4,18 @@
       "rule": {
         "name": "aws_resource_missing_tags",
         "severity": "info",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.37.0/docs/rules/aws_resource_missing_tags.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v{{.Version}}/docs/rules/aws_resource_missing_tags.md"
       },
       "message": "The resource is missing the following tags: \"Environment\", \"Name\", \"Type\".",
       "range": {
         "filename": "template.tf",
         "start": {
-          "line": 5,
-          "column": 1
+          "line": 2,
+          "column": 10
         },
         "end": {
-          "line": 5,
-          "column": 41
+          "line": 2,
+          "column": 25
         }
       },
       "callers": []

--- a/integration/rule-config/result.json.tmpl
+++ b/integration/rule-config/result.json.tmpl
@@ -4,7 +4,7 @@
       "rule": {
         "name": "aws_s3_bucket_name",
         "severity": "error",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.37.0/docs/rules/aws_s3_bucket_name.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v{{.Version}}/docs/rules/aws_s3_bucket_name.md"
       },
       "message": "Bucket name \"foo_bar\" does not match regex \"^[a-z\\-]+$\"",
       "range": {
@@ -24,7 +24,7 @@
       "rule": {
         "name": "aws_s3_bucket_name",
         "severity": "error",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.37.0/docs/rules/aws_s3_bucket_name.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v{{.Version}}/docs/rules/aws_s3_bucket_name.md"
       },
       "message": "Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-). (name: \"foo_bar\", regex: \"[^a-z0-9\\\\.\\\\-]\")",
       "range": {


### PR DESCRIPTION
Remove hard-coded versions from integration tests for release automation.
The `result.json.tmpl` file will be able to dynamically inject metadata using the `text/template` package.