### PR TITLE
provider_missing_default_tags: correctly handle unknown values

### DIFF
--- a/rules/aws_provider_missing_default_tags.go
+++ b/rules/aws_provider_missing_default_tags.go
@@ -140,7 +140,7 @@ func (r *AwsProviderMissingDefaultTagsRule) Check(runner tflint.Runner) error {
 			}, nil)
 
 			if err != nil {
-				logger.Warn("Could not evaluate tags, skipping %s.", provider.Labels[0]+"."+providerAlias+"."+providerDefaultTagsBlockName+"."+providerTagsAttributeName)
+				logger.Warn("Could not evaluate tags, skipping %s.%s.%s.%s: %s", provider.Labels[0], providerAlias, providerDefaultTagsBlockName, providerTagsAttributeName, err)
 				continue
 			}
 

--- a/rules/aws_provider_missing_default_tags.go
+++ b/rules/aws_provider_missing_default_tags.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -140,13 +139,9 @@ func (r *AwsProviderMissingDefaultTagsRule) Check(runner tflint.Runner) error {
 				return nil
 			}, nil)
 
-			if errors.Is(err, tflint.ErrUnknownValue) {
-				logger.Warn("The missing aws tags rule can only evaluate provided variables, skipping %s.", provider.Labels[0]+"."+providerAlias+"."+providerDefaultTagsBlockName+"."+providerTagsAttributeName)
-				continue
-			}
-
 			if err != nil {
-				return err
+				logger.Warn("Could not evaluate tags, skipping %s.", provider.Labels[0]+"."+providerAlias+"."+providerDefaultTagsBlockName+"."+providerTagsAttributeName)
+				continue
 			}
 
 			// Check tags

--- a/rules/aws_provider_missing_default_tags_test.go
+++ b/rules/aws_provider_missing_default_tags_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
-	"github.com/stretchr/testify/assert"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
 
@@ -14,7 +13,6 @@ func Test_AwsProviderMissingDefaultTags(t *testing.T) {
 		Content  string
 		Config   string
 		Expected helper.Issues
-		Err      string
 	}{
 		{
 			Name: "Default tags for provider",
@@ -172,7 +170,7 @@ rule "aws_provider_missing_default_tags" {
   enabled = true
   tags = ["Bazz", "Fooz"]
 }`,
-			Err: "Can't use a null value as a key.",
+			Expected: helper.Issues{},
 		},
 	}
 
@@ -182,14 +180,7 @@ rule "aws_provider_missing_default_tags" {
 		t.Run(tc.Name, func(t *testing.T) {
 			runner := helper.TestRunner(t, map[string]string{"module.tf": tc.Content, ".tflint.hcl": tc.Config})
 
-			err := rule.Check(runner)
-
-			if tc.Err != "" {
-				assert.ErrorContains(t, err, tc.Err)
-				return
-			}
-
-			if err != nil {
+			if err := rule.Check(runner); err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
 

--- a/rules/aws_provider_missing_default_tags_test.go
+++ b/rules/aws_provider_missing_default_tags_test.go
@@ -159,8 +159,6 @@ provider "aws" {
     }
 	}
 
-  // This variable MUST be set, otherwise the configuration is invalid
-  // The rule should error when encountering this in the tags expression
   variable "tag" {
     type = string
   }


### PR DESCRIPTION
Fixes a bug where `provider_missing_default_tags` does not correctly handle unknown tags. Adds the missing test coverage and then fixes the failing tests by correcting the control flow for unknown values.

## Cases

### Unknown

The incorrect flow:

```go
if !known {
  return nil
}
```

Doing this _inside_ the `EvaluateExpr` callback effectively ignores the value and leaves `providerTags` empty before checking for unset tags. Instead, unknown values need to short circuit the comparison. So I've returned an error, borrowing `tflint.UnknownError`. 

### Null

The multiple cases where errors are silently discarded was a red flag:

```go
if err != nil {
  return nil
}
```

Now, all errors are returned _except_ evaluation errors of the `tags` attribute. This could be due to an explicit unknown value error or it could be a null value. As in:

```tf
provider "aws" {
  default_tags {
    tags = {
      (var.tag): "bar"
    }
  }
}

variable "tag" {
  type = string
}
```

This is technically not valid configuration, as `var.tag` is `null`, and `null` is not a valid map key. We could just return this error and insist users pass a variable value to TFLint or set a default to make the configuration valid. I initially went that path.

But for the sake of backward compatibility, _any_ error will short circuit checking (as before). But now, the warning log happens _outside_ of the `EvalauteExpr` callback, for _all_ errors, such that they are no longer wholly silent. If the rule is skipping a tag map because of a null key error, it will print that error in a warning.

## Related

Closes #850

