### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete regular expression for hostnames

### DIFF
--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -19,7 +19,7 @@ import (
 
 var token = os.Getenv("GITHUB_TOKEN")
 var versionRegexp = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
-var goModRequireSDKRegexp = regexp.MustCompile(`github.com/terraform-linters/tflint-plugin-sdk v(.+)`)
+var goModRequireSDKRegexp = regexp.MustCompile(`github\.com/terraform-linters/tflint-plugin-sdk v(.+)`)
 
 func main() {
 	if err := os.Chdir("../../"); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/terraform-linters/tflint-ruleset-aws/security/code-scanning/6](https://github.com/terraform-linters/tflint-ruleset-aws/security/code-scanning/6)

To fix the issue, the dot (`.`) in the regular expression should be escaped to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\.`. Additionally, using a raw string literal (enclosed in backticks) avoids the need to double-escape the backslash, making the regular expression more readable. The corrected regular expression will be: `` `github\.com/terraform-linters/tflint-plugin-sdk v(.+)` ``.

The change should be made on line 22 of the file `tools/release/main.go`, where the `goModRequireSDKRegexp` variable is defined.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
