### PR TITLE
Add missing AWS access analyzer types

### DIFF
--- a/rules/models/aws_accessanalyzer_analyzer_invalid_type.go
+++ b/rules/models/aws_accessanalyzer_analyzer_invalid_type.go
@@ -29,6 +29,8 @@ func NewAwsAccessanalyzerAnalyzerInvalidTypeRule() *AwsAccessanalyzerAnalyzerInv
 			"ORGANIZATION",
 			"ACCOUNT_UNUSED_ACCESS",
 			"ORGANIZATION_UNUSED_ACCESS",
+			"ACCOUNT_INTERNAL_ACCESS",
+			"ORGANIZATION_INTERNAL_ACCESS",
 		},
 	}
 }
@@ -72,7 +74,7 @@ func (r *AwsAccessanalyzerAnalyzerInvalidTypeRule) Check(runner tflint.Runner) e
 			continue
 		}
 
-		err := runner.EvaluateExpr(attribute.Expr, func (val string) error {
+		err := runner.EvaluateExpr(attribute.Expr, func(val string) error {
 			found := false
 			for _, item := range r.enum {
 				if item == val {


### PR DESCRIPTION
Extend the rule for checking on invalid AWS access analyzer types by adding two missing entries:

* ACCOUNT_INTERNAL_ACCESS
* ORGANIZATION_INTERNAL_ACCESS

Source: [CreateAnalzer API documentation](https://docs.aws.amazon.com/access-analyzer/latest/APIReference/API_CreateAnalyzer.html)
