### PR TITLE
`resource_missing_tags`: handle explicit refs to default provider

### DIFF
--- a/rules/aws_resource_missing_tags.go
+++ b/rules/aws_resource_missing_tags.go
@@ -81,13 +81,10 @@ func (r *AwsResourceMissingTagsRule) getProviderLevelTags(runner tflint.Runner) 
 
 	// Get provider default tags
 	allProviderTags := make(map[string][]string)
-	var providerAlias string
 	for _, provider := range providerBody.Blocks.OfType(providerAttributeName) {
-		// Get the alias attribute, in terraform when there is a single aws provider its called "default"
-		providerAttr, ok := provider.Body.Attributes["alias"]
-		if !ok {
-			providerAlias = "default"
-		} else {
+		// Get the alias attribute. Empty string represents the default provider.
+		var providerAlias string
+		if providerAttr, ok := provider.Body.Attributes["alias"]; ok {
 			err := runner.EvaluateExpr(providerAttr.Expr, func(alias string) error {
 				logger.Debug("Walk `%s` provider", providerAlias)
 				providerAlias = alias
@@ -164,7 +161,7 @@ func (r *AwsResourceMissingTagsRule) Check(runner tflint.Runner) error {
 		}
 
 		for _, resource := range resources.Blocks {
-			providerAlias := "default"
+			var providerAlias string
 			// Override the provider alias if defined
 			if val, ok := resource.Body.Attributes[providerAttributeName]; ok {
 				provider, diagnostics := aws.DecodeProviderConfigRef(val.Expr, "provider")

--- a/rules/aws_resource_missing_tags_test.go
+++ b/rules/aws_resource_missing_tags_test.go
@@ -525,6 +525,30 @@ rule "aws_resource_missing_tags" {
 				},
 			},
 		},
+		{
+			Name: "Provider reference without alias (issue #1002)",
+			Content: `
+provider "aws" {
+  region = "eu-west-1"
+  default_tags {
+    tags = {
+      "layer": "app"
+      "type": "service"
+    }
+  }
+}
+
+resource "aws_iam_user" "bedrock" {
+  provider = aws
+  name = "test"
+}`,
+			Config: `
+rule "aws_resource_missing_tags" {
+  enabled = true
+  tags = ["layer", "type"]
+}`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewAwsResourceMissingTagsRule()


### PR DESCRIPTION
Fixes the `aws_resource_missing_tags` rule to correctly handle resources that use `provider = aws` without an alias. Previously, such resources would not inherit `default_tags` from the provider configuration.

## Issue

When a resource specifies `provider = aws` without an alias (e.g., `provider = aws.test`), the `DecodeProviderConfigRef` function correctly parses the expression but returns an empty string for the `Alias` field. The rule implementation used `"default"` as a magic string for the default provider, creating a mismatch when looking up provider-level `default_tags`.

This mismatch caused resources using `provider = aws` to be treated as having no provider-level tags, incorrectly reporting missing tags even when `default_tags` were defined at the provider level.

## Changes

- Updates `aws_resource_missing_tags.go` to use empty string (`""`) instead of `"default"` as the map key for the default provider
- This matches what `DecodeProviderConfigRef` returns when no alias is specified
- Adds test case verifying that `provider = aws` references correctly inherit provider-level `default_tags`

## Testing

Added test case that validates resources using `provider = aws` without an alias correctly inherit `default_tags` from the provider configuration. All existing tests continue to pass.

## References

Closes #1002
