### PR TITLE
Check if aws_iam_policy sets policy value from reference

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -70,6 +70,7 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_policy_attachment_exclusive_attachment](aws_iam_policy_attachment_exclusive_attachment.md)|Consider alternative resources to `aws_iam_policy_attachment`||
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
+|[aws_iam_policy_use_policy_reference](aws_iam_policy_use_policy_reference.md)|Check that `iam_policy` sources its `policy` from a reference||
 |[aws_iam_role_deprecated_policy_attributes](aws_iam_role_deprecated_policy_attributes.md)|Disallow using deprecated policy attributes of `aws_iam_role`||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|

--- a/docs/rules/README.md.tmpl
+++ b/docs/rules/README.md.tmpl
@@ -70,6 +70,7 @@ These rules enforce best practices and naming conventions:
 |[aws_iam_policy_attachment_exclusive_attachment](aws_iam_policy_attachment_exclusive_attachment.md)|Consider alternative resources to `aws_iam_policy_attachment`||
 |[aws_iam_policy_document_gov_friendly_arns](aws_iam_policy_document_gov_friendly_arns.md)|Ensure `iam_policy_document` data sources do not contain `arn:aws:` ARN's||
 |[aws_iam_policy_gov_friendly_arns](aws_iam_policy_gov_friendly_arns.md)|Ensure `iam_policy` resources do not contain `arn:aws:` ARN's||
+|[aws_iam_policy_use_policy_reference](aws_iam_policy_use_policy_reference.md)|Check that `iam_policy` sources its `policy` from a reference||
 |[aws_iam_role_deprecated_policy_attributes](aws_iam_role_deprecated_policy_attributes.md)|Disallow using deprecated policy attributes of `aws_iam_role`||
 |[aws_iam_role_policy_gov_friendly_arns](aws_iam_role_policy_gov_friendly_arns.md)|Ensure `iam_role_policy` resources do not contain `arn:aws:` ARN's||
 |[aws_instance_previous_type](aws_instance_previous_type.md)|Disallow using previous generation instance types|✔|

--- a/docs/rules/aws_iam_policy_use_policy_reference.md
+++ b/docs/rules/aws_iam_policy_use_policy_reference.md
@@ -1,6 +1,6 @@
 # aws_iam_policy_use_policy_reference
 
-Check the source of the value for `policy` in an `aws_iam_policy` to catch values not generated from resources or data sources such as `data.aws_iam_policy_document`.
+Check the source of the value for `policy` in an `aws_iam_policy` to catch values not generated from resources or data sources such as `data.aws_iam_policy_document`. This includes function calls, except those that read from files (`file` and `templatefile`).
 
 ## Configuration
 

--- a/docs/rules/aws_iam_policy_use_policy_reference.md
+++ b/docs/rules/aws_iam_policy_use_policy_reference.md
@@ -1,0 +1,94 @@
+# aws_iam_policy_use_policy_reference
+
+Check the source of the value for `policy` in an `aws_iam_policy` to catch values not generated from resources or data sources such as `data.aws_iam_policy_document`.
+
+## Configuration
+
+```hcl
+rule "aws_iam_policy_use_policy_reference" {
+  enabled = true
+}
+```
+
+## Example
+
+```hcl
+resource "aws_iam_policy" "raw_json" {
+  name = "test_policy"
+
+  policy = <<-EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": ["ec2:Describe*"],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::<bucketname>/*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "jsonencode" {
+  name = "test_policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+```
+
+```
+$ tflint
+2 issue(s) found:
+
+Notice: The policy does not reference an object (aws_iam_policy_use_policy_reference)
+
+  on main.tf line 4:
+   4:   policy = <<-EOF
+   5: {
+   6:   "Version": "2012-10-17",
+   7:   "Statement": [
+   8:     {
+   9:       "Action": ["ec2:Describe*"],
+  10:       "Effect": "Allow",
+  11:       "Resource": "arn:aws:s3:::<bucketname>/*"
+  12:     }
+  13:   ]
+  14: }
+  15: EOF
+
+Notice: The policy does not reference an object (aws_iam_policy_use_policy_reference)
+
+  on main.tf line 21:
+  21:   policy = jsonencode({
+  22:     Version = "2012-10-17"
+  23:     Statement = [
+  24:       {
+  25:         Action = [
+  26:           "ec2:Describe*",
+  27:         ]
+  28:         Effect   = "Allow"
+  29:         Resource = "*"
+  30:       },
+  31:     ]
+  32:   })
+```
+
+## Why
+
+The `policy` argument takes a string, which must be well-formed. Specifically, it must be a JSON-formatted IAM policy document. By passing HCL to `jsonencode` we can ensure that it is JSON-formatted, but not that it is the correct structure for an IAM policy document. This check aims to make it simpler to assert correctness before applying.
+
+## How To Fix
+
+Define an `aws_iam_policy_document` data source and assign its `json` attribute to `policy`.

--- a/rules/aws_iam_policy_use_policy_reference.go
+++ b/rules/aws_iam_policy_use_policy_reference.go
@@ -1,0 +1,76 @@
+package rules
+
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-aws/project"
+)
+
+// AwsIAMPolicyUsePolicyReference checks if aws_iam_policy doesn't assign to
+// policy from a reference
+type AwsIAMPolicyUsePolicyReference struct {
+	tflint.DefaultRule
+
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsIAMPolicyUsePolicyReferenceRule returns new rule with default attributes
+func NewAwsIAMPolicyUsePolicyReferenceRule() *AwsIAMPolicyUsePolicyReference {
+	return &AwsIAMPolicyUsePolicyReference{
+		resourceType:  "aws_iam_policy",
+		attributeName: "policy",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsIAMPolicyUsePolicyReference) Name() string {
+	return "aws_iam_policy_use_policy_reference"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsIAMPolicyUsePolicyReference) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *AwsIAMPolicyUsePolicyReference) Severity() tflint.Severity {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *AwsIAMPolicyUsePolicyReference) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks if policy is not referencing an object reference
+func (r *AwsIAMPolicyUsePolicyReference) Check(runner tflint.Runner) error {
+	issueMessage := "The policy does not reference an object"
+
+	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{{Name: r.attributeName}},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes[r.attributeName]
+		if !exists {
+			continue
+		}
+
+		// Check if the value is a reference and if so permit it.
+		if _, ok := attribute.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
+			continue
+		}
+
+		if err := runner.EmitIssue(r, issueMessage, attribute.Range); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rules/aws_iam_policy_use_policy_reference.go
+++ b/rules/aws_iam_policy_use_policy_reference.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"slices"
+
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
@@ -65,6 +67,14 @@ func (r *AwsIAMPolicyUsePolicyReference) Check(runner tflint.Runner) error {
 		// Check if the value is a reference and if so permit it.
 		if _, ok := attribute.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
 			continue
+		}
+
+		// Check if the value is a call to file or templatefile and if so permit it.
+		permittedFunctions := []string{"file", "templatefile"}
+		if functionCall, ok := attribute.Expr.(*hclsyntax.FunctionCallExpr); ok {
+			if slices.Contains(permittedFunctions, functionCall.Name) {
+				continue
+			}
 		}
 
 		if err := runner.EmitIssue(r, issueMessage, attribute.Range); err != nil {

--- a/rules/aws_iam_policy_use_policy_reference_test.go
+++ b/rules/aws_iam_policy_use_policy_reference_test.go
@@ -1,0 +1,89 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsIAMPolicyUsePolicyReference(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "policy uses raw JSON",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name = "test_policy"
+	policy = <<EOF
+	{
+		"Version": "2012-10-17",
+		"Statement": [
+		{
+			"Effect": "Allow",
+			"Resource": "arn:aws:s3:::<bucketname>/*""
+		}
+		]
+	}
+EOF
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsIAMPolicyUsePolicyReferenceRule(),
+					Message: "The policy does not reference an object",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 4, Column: 2},
+						End:      hcl.Pos{Line: 14, Column: 4},
+					},
+				},
+			},
+		},
+		{
+			Name: "policy uses jsonencode",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name   = "test_policy"
+	policy = jsonencode()
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsIAMPolicyUsePolicyReferenceRule(),
+					Message: "The policy does not reference an object",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 4, Column: 2},
+						End:      hcl.Pos{Line: 4, Column: 23},
+					},
+				},
+			},
+		},
+		{
+			Name: "policy uses data.aws_iam_policy_document",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name   = "test_policy"
+	policy = data.aws_iam_policy_document.document.json # (not shown)
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsIAMPolicyUsePolicyReferenceRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/aws_iam_policy_use_policy_reference_test.go
+++ b/rules/aws_iam_policy_use_policy_reference_test.go
@@ -73,6 +73,27 @@ resource "aws_iam_policy" "policy" {
 `,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "policy uses file call",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name   = "test_policy"
+	policy = file("path/to/policy.json")
+}
+`,
+			Expected: helper.Issues{},
+		},
+
+		{
+			Name: "policy uses templatefile call",
+			Content: `
+resource "aws_iam_policy" "policy" {
+	name   = "test_policy"
+	policy = templatefile("path/to/policy.json.tmpl")
+}
+`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewAwsIAMPolicyUsePolicyReferenceRule()

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -19,6 +19,7 @@ var manualRules = []tflint.Rule{
 	NewAwsIAMPolicyDocumentGovFriendlyArnsRule(),
 	NewAwsIAMPolicyGovFriendlyArnsRule(),
 	NewAwsIAMRolePolicyGovFriendlyArnsRule(),
+	NewAwsIAMPolicyUsePolicyReferenceRule(),
 	NewAwsInstancePreviousTypeRule(),
 	NewAwsMqBrokerInvalidEngineTypeRule(),
 	NewAwsMqConfigurationInvalidEngineTypeRule(),


### PR DESCRIPTION
The `aws_iam_policy` resource's `policy` argument takes a string that must match the structure of a JSON-formatted IAM policy document. Often this is done by assigning to the output of `jsonencode` which is passed some HCL -- however, this doesn't guarantee that the string is well-formed, only that it is JSON, and can result in errors at apply-time.

The spirit of this check is to ensure that `policy` values are from references. In practice, it's anticipated that these will be `data.aws_iam_policy_document.foo.json` objects, but it also permits locals, resources and data sources of any type.

The motivation is that I occasionally come across incorrect (or not obviously correct) `jsonencode(...)` inputs in code review, which this would catch automatically.

If this seems reasonable, I'll do the same for `aws_iam_role`'s `assume_role_policy` argument.