### PR TITLE
Add FreeBSD build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
   - targets:
       - darwin_amd64
       - darwin_arm64
+      - freebsd_amd64
       - linux_386
       - linux_amd64
       - linux_arm


### PR DESCRIPTION
Thank you for making tflint and its very useful rulesets!

FreeBSD packages `tflint`, but none of the useful plugins seem to be released for this operating system yet. This very small patch adds `freebsd_amd64` as a build target.

If testing before new releases is a concern, I volunteer to do it. I am using `tflint` in all my tofu projects and using FreeBSD a lot. If this contribution is well received, I will happily submit the same change to the azurerm ruleset too.