### PR TITLE
fix: cache deep check AWS clients across runners

### DIFF
--- a/aws/client_cache.go
+++ b/aws/client_cache.go
@@ -1,0 +1,50 @@
+package aws
+
+import "sync"
+
+// clientFactory builds a Client from credentials. Defaults to NewClient;
+// overridable in tests to count and control client construction.
+type clientFactory func(Credentials) (Client, error)
+
+type clientEntry struct {
+	once   sync.Once
+	client Client
+	err    error
+}
+
+// clientCache builds at most one Client per distinct Credentials value and
+// shares it across all runners. Safe for concurrent use.
+type clientCache struct {
+	factory clientFactory
+	mu      sync.Mutex
+	entries map[Credentials]*clientEntry
+}
+
+func newClientCache(factory clientFactory) *clientCache {
+	return &clientCache{factory: factory, entries: map[Credentials]*clientEntry{}}
+}
+
+func (c *clientCache) get(creds Credentials) (Client, error) {
+	c.mu.Lock()
+	entry, ok := c.entries[creds]
+	if !ok {
+		entry = &clientEntry{}
+		c.entries[creds] = entry
+	}
+	c.mu.Unlock()
+
+	entry.once.Do(func() {
+		entry.client, entry.err = c.factory(creds)
+	})
+
+	if entry.err != nil {
+		// Do not cache failures: drop the entry so a later call retries.
+		c.mu.Lock()
+		if c.entries[creds] == entry {
+			delete(c.entries, creds)
+		}
+		c.mu.Unlock()
+		return nil, entry.err
+	}
+	return entry.client, nil
+}

--- a/aws/client_cache_test.go
+++ b/aws/client_cache_test.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func Test_clientCache_get(t *testing.T) {
+	cases := []struct {
+		name  string
+		creds []Credentials
+		calls int
+	}{
+		{
+			name: "same credential reused across sequential calls",
+			creds: []Credentials{
+				{Region: "us-east-1"},
+				{Region: "us-east-1"},
+				{Region: "us-east-1"},
+			},
+			calls: 1,
+		},
+		{
+			name: "distinct credentials build distinct clients",
+			creds: []Credentials{
+				{Region: "us-east-1"},
+				{Region: "us-west-2"},
+				{Region: "us-east-1"},
+			},
+			calls: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var count int64
+			cache := newClientCache(func(Credentials) (Client, error) {
+				atomic.AddInt64(&count, 1)
+				return &AwsClient{}, nil
+			})
+
+			clients := map[Credentials]Client{}
+			for _, creds := range tc.creds {
+				client, err := cache.get(creds)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				if prev, ok := clients[creds]; ok {
+					if prev != client {
+						t.Fatalf("expected the same client for %+v, got a different one", creds)
+					}
+				} else {
+					clients[creds] = client
+				}
+			}
+
+			if got := atomic.LoadInt64(&count); got != int64(tc.calls) {
+				t.Fatalf("expected factory to be called %d times, got %d", tc.calls, got)
+			}
+		})
+	}
+}
+
+func Test_clientCache_get_concurrent(t *testing.T) {
+	const goroutines = 32
+
+	var count int64
+	release := make(chan struct{})
+	var entered sync.WaitGroup
+	entered.Add(goroutines)
+
+	cache := newClientCache(func(Credentials) (Client, error) {
+		atomic.AddInt64(&count, 1)
+		return &AwsClient{}, nil
+	})
+
+	creds := Credentials{Region: "us-east-1"}
+	clients := make([]Client, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			entered.Done()
+			<-release
+			client, err := cache.get(creds)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+				return
+			}
+			clients[i] = client
+		}(i)
+	}
+
+	entered.Wait()
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&count); got != 1 {
+		t.Fatalf("expected factory to be called exactly once, got %d", got)
+	}
+	for i, client := range clients {
+		if client != clients[0] {
+			t.Fatalf("expected all goroutines to share one client, goroutine %d differs", i)
+		}
+	}
+}
+
+func Test_clientCache_get_doesNotCacheErrors(t *testing.T) {
+	var count int64
+	wantErr := errors.New("transient failure")
+	cache := newClientCache(func(Credentials) (Client, error) {
+		if atomic.AddInt64(&count, 1) == 1 {
+			return nil, wantErr
+		}
+		return &AwsClient{}, nil
+	})
+
+	creds := Credentials{Region: "us-east-1"}
+
+	if _, err := cache.get(creds); !errors.Is(err, wantErr) {
+		t.Fatalf("expected first get to return %v, got %v", wantErr, err)
+	}
+
+	client, err := cache.get(creds)
+	if err != nil {
+		t.Fatalf("expected second get to succeed, got %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected second get to return a client")
+	}
+	if got := atomic.LoadInt64(&count); got != 2 {
+		t.Fatalf("expected factory to be called twice, got %d", got)
+	}
+}

--- a/aws/ruleset.go
+++ b/aws/ruleset.go
@@ -8,11 +8,13 @@ import (
 // RuleSet is the custom ruleset for the AWS provider plugin.
 type RuleSet struct {
 	tflint.BuiltinRuleSet
-	config *Config
+	config  *Config
+	clients *clientCache
 }
 
 func (r *RuleSet) ConfigSchema() *hclext.BodySchema {
 	r.config = &Config{}
+	r.clients = newClientCache(NewClient)
 	return hclext.ImpliedBodySchema(r.config)
 }
 
@@ -43,5 +45,5 @@ func (r *RuleSet) ApplyConfig(body *hclext.BodyContent) error {
 
 // NewRunner injects a custom AWS runner
 func (r *RuleSet) NewRunner(runner tflint.Runner) (tflint.Runner, error) {
-	return NewRunner(runner, r.config)
+	return NewRunner(runner, r.config, r.clients)
 }

--- a/aws/ruleset.go
+++ b/aws/ruleset.go
@@ -14,7 +14,6 @@ type RuleSet struct {
 
 func (r *RuleSet) ConfigSchema() *hclext.BodySchema {
 	r.config = &Config{}
-	r.clients = newClientCache(NewClient)
 	return hclext.ImpliedBodySchema(r.config)
 }
 
@@ -24,6 +23,8 @@ func (r *RuleSet) ApplyConfig(body *hclext.BodyContent) error {
 	if diags.HasErrors() {
 		return diags
 	}
+
+	r.clients = newClientCache(NewClient)
 
 	if r.config.DeepCheck {
 		return nil

--- a/aws/runner.go
+++ b/aws/runner.go
@@ -17,7 +17,7 @@ type Runner struct {
 }
 
 // NewRunner returns a custom AWS runner.
-func NewRunner(runner tflint.Runner, config *Config) (*Runner, error) {
+func NewRunner(runner tflint.Runner, config *Config, cache *clientCache) (*Runner, error) {
 	clients := map[string]Client{
 		"aws": nil,
 	}
@@ -30,7 +30,7 @@ func NewRunner(runner tflint.Runner, config *Config) (*Runner, error) {
 			credentials["aws"] = Credentials{}
 		}
 		for k, cred := range credentials {
-			client, err := NewClient(cred.Merge(config.toCredentials()))
+			client, err := cache.get(cred.Merge(config.toCredentials()))
 			if err != nil {
 				return nil, err
 			}

--- a/aws/runner_test.go
+++ b/aws/runner_test.go
@@ -1,0 +1,72 @@
+package aws
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_NewRunner_sharesClientsAcrossRunners(t *testing.T) {
+	// Three providers, two distinct credentials (default + alias "west" share
+	// us-east-1, alias "other" uses us-west-2).
+	content := `
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "AKID"
+  secret_key = "SECRET"
+}
+
+provider "aws" {
+  alias      = "west"
+  region     = "us-east-1"
+  access_key = "AKID"
+  secret_key = "SECRET"
+}
+
+provider "aws" {
+  alias      = "other"
+  region     = "us-west-2"
+  access_key = "AKID"
+  secret_key = "SECRET"
+}
+`
+
+	cases := []struct {
+		name      string
+		config    *Config
+		wantCalls int64
+	}{
+		{
+			name:      "deep check shares clients by credential across runners",
+			config:    &Config{DeepCheck: true},
+			wantCalls: 2,
+		},
+		{
+			name:      "deep check disabled never builds clients",
+			config:    &Config{DeepCheck: false},
+			wantCalls: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var count int64
+			cache := newClientCache(func(Credentials) (Client, error) {
+				atomic.AddInt64(&count, 1)
+				return &AwsClient{}, nil
+			})
+
+			for range 2 {
+				runner := helper.TestRunner(t, map[string]string{"providers.tf": content})
+				if _, err := NewRunner(runner, tc.config, cache); err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+			}
+
+			if got := atomic.LoadInt64(&count); got != tc.wantCalls {
+				t.Fatalf("expected factory to be called %d times, got %d", tc.wantCalls, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`deep_check` could take 10s of minutes and fail with network errors like `dial tcp: lookup sts.eu-west-3.amazonaws.com: no such host` or `Cannot assume IAM Role` on configurations with many `provider "aws"` instances. Fixes #1113.

The reported config had ~60 provider instances across accounts and regions. Each run opened hundreds of concurrent connections and either crawled or failed outright. `--max-workers` made no difference. Only `--no-parallel-runners` avoided the errors, and it was far slower.

## Root Cause

With `deep_check`, the ruleset builds an AWS client for every provider, and validating each client's credentials makes an STS network call (`GetCallerIdentity`, plus two `AssumeRole` calls when `assume_role` is set). `NewRunner` runs once per runner, and tflint creates one runner for the root module plus one per module call. Every runner reads the same root-module providers and rebuilds the same clients from scratch, so the work is `runners × providers` identical STS calls.

tflint dispatches those per-runner calls as one goroutine per runner, bounded only by `--no-parallel-runners`. `--max-workers` bounds a different phase, the `--recursive` subprocess pool, so it has no effect here. The result is a burst of `runners × providers` connections fanned across regions. That burst overwhelms the DNS resolver and exhausts the socket budget, which is consistent with the `no such host` errors. STS rate limiting and SDK retries account for the runtime.

I measured the shape against a local mock STS endpoint that counts calls and concurrency:

| providers × modules | runners | STS calls (before) |
|---|---|---|
| 10 × 10 | 11 | 110 |
| 40 × 40 | 41 | 1,640 |
| 60 × 60 | 61 | 3,660 |

At 30 × 30 with 50 ms of injected latency, every `--max-workers` value held peak concurrency at 30 and ran in ~4 s, while `--no-parallel-runners` dropped concurrency to 1 but took 52 s. This reproduces the reporter's behavior.

## Fix

The clients depend only on their `Credentials`, which is identical for every runner because the providers always come from the root module. The concrete `AwsClient` behind the `Client` interface holds only AWS SDK service clients and is safe for concurrent use. So a client can be built once per distinct credential and shared across every runner.

This adds a credential-keyed cache (`aws/client_cache.go`) on the `RuleSet`, which is a single instance for the whole plugin process. `NewRunner` routes every client construction through it. A `sync.Once` per cache entry dedupes concurrent first-touches of the same credential, so a burst of runners triggers at most one build per credential. Failures are not cached, so a transient error can still be retried.

Cost now scales with distinct credentials, not `runners × providers`:

| scenario | before | after |
|---|---|---|
| 60 providers × 60 modules, shared credential | 3,660 calls | 1 |
| 5 distinct assume-role providers × 6 runners | 90 calls, peak 30 | 15 calls, peak 1 |

Wall time stays roughly flat as the module count grows, instead of climbing with it.

I kept the cache in the ruleset rather than changing tflint core. Core's unbounded per-runner fan-out is a real gap, but the cache makes it moot here. Once warm, every runner does in-memory lookups with no network calls.

## Testing

`aws/client_cache_test.go` covers sequential reuse of one credential, concurrent first-touch of the same credential through a release barrier that races many goroutines into a single build, distinct credentials building distinct clients, and a failed build that is not cached so the next call rebuilds. 

`aws/runner_test.go` drives `NewRunner` twice over a fixture with three providers and two distinct credentials, asserting two client builds rather than six, which exercises both intra-runner dedup and cross-runner sharing.
