### PR TITLE
Fix aws_route rules to recognize core_network_arn and odb_network_arn targets

### DIFF
--- a/docs/rules/aws_route_not_specified_target.md
+++ b/docs/rules/aws_route_not_specified_target.md
@@ -15,7 +15,7 @@ resource "aws_route" "foo" {
 $ tflint
 1 issue(s) found:
 
-Error: The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id. (aws_route_not_specified_target)
+Error: The routing target is not specified, each aws_route must contain either carrier_gateway_id, core_network_arn, egress_only_gateway_id, gateway_id, instance_id, local_gateway_id, nat_gateway_id, network_interface_id, odb_network_arn, transit_gateway_id, vpc_endpoint_id or vpc_peering_connection_id. (aws_route_not_specified_target)
 
   on template.tf line 1:
    1: resource "aws_route" "foo" {

--- a/rules/aws_route_not_specified_target.go
+++ b/rules/aws_route_not_specified_target.go
@@ -44,19 +44,7 @@ func (r *AwsRouteNotSpecifiedTargetRule) Link() string {
 // Check checks whether a target is defined in a resource
 func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
-		Attributes: []hclext.AttributeSchema{
-			{Name: "gateway_id"},
-			{Name: "egress_only_gateway_id"},
-			{Name: "nat_gateway_id"},
-			{Name: "instance_id"},
-			{Name: "vpc_peering_connection_id"},
-			{Name: "network_interface_id"},
-			{Name: "transit_gateway_id"},
-			{Name: "vpc_endpoint_id"},
-			{Name: "carrier_gateway_id"},
-			{Name: "local_gateway_id"},
-			{Name: "core_network_arn"},
-		},
+		Attributes: routeTargetAttributes,
 	}, nil)
 	if err != nil {
 		return err
@@ -79,7 +67,7 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 		if len(resource.Body.Attributes)-nullAttributes == 0 {
 			runner.EmitIssue(
 				r,
-				"The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id.",
+				"The routing target is not specified, each aws_route must contain either carrier_gateway_id, core_network_arn, egress_only_gateway_id, gateway_id, instance_id, local_gateway_id, nat_gateway_id, network_interface_id, odb_network_arn, transit_gateway_id, vpc_endpoint_id or vpc_peering_connection_id.",
 				resource.DefRange,
 			)
 		}

--- a/rules/aws_route_not_specified_target.go
+++ b/rules/aws_route_not_specified_target.go
@@ -67,7 +67,7 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner tflint.Runner) error {
 		if len(resource.Body.Attributes)-nullAttributes == 0 {
 			runner.EmitIssue(
 				r,
-				"The routing target is not specified, each aws_route must contain either carrier_gateway_id, core_network_arn, egress_only_gateway_id, gateway_id, instance_id, local_gateway_id, nat_gateway_id, network_interface_id, odb_network_arn, transit_gateway_id, vpc_endpoint_id or vpc_peering_connection_id.",
+				routeTargetNotSpecifiedMessage,
 				resource.DefRange,
 			)
 		}

--- a/rules/aws_route_not_specified_target_test.go
+++ b/rules/aws_route_not_specified_target_test.go
@@ -22,7 +22,7 @@ resource "aws_route" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsRouteNotSpecifiedTargetRule(),
-					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id.",
+					Message: "The routing target is not specified, each aws_route must contain either carrier_gateway_id, core_network_arn, egress_only_gateway_id, gateway_id, instance_id, local_gateway_id, nat_gateway_id, network_interface_id, odb_network_arn, transit_gateway_id, vpc_endpoint_id or vpc_peering_connection_id.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 2, Column: 1},
@@ -104,7 +104,7 @@ resource "aws_route" "foo" {
 			Expected: helper.Issues{
 				{
 					Rule:    NewAwsRouteNotSpecifiedTargetRule(),
-					Message: "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, vpc_peering_connection_id, core_network_arn or vpc_endpoint_id.",
+					Message: "The routing target is not specified, each aws_route must contain either carrier_gateway_id, core_network_arn, egress_only_gateway_id, gateway_id, instance_id, local_gateway_id, nat_gateway_id, network_interface_id, odb_network_arn, transit_gateway_id, vpc_endpoint_id or vpc_peering_connection_id.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
 						Start:    hcl.Pos{Line: 2, Column: 1},
@@ -128,6 +128,15 @@ resource "aws_route" "foo" {
 resource "aws_route" "foo" {
 	route_table_id = "rtb-1234abcd"
 	core_network_arn = "arn:aws:networkmanager::230703758040:core-network/core-network-0ce39423cf52b4c76"
+}`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "odb_network_arn is specified",
+			Content: `
+resource "aws_route" "foo" {
+	route_table_id = "rtb-1234abcd"
+	odb_network_arn = "arn:aws:odb:us-east-1:230703758040:odb-network/odbnet-abcd1234"
 }`,
 			Expected: helper.Issues{},
 		},

--- a/rules/aws_route_specified_multiple_targets.go
+++ b/rules/aws_route_specified_multiple_targets.go
@@ -44,18 +44,7 @@ func (r *AwsRouteSpecifiedMultipleTargetsRule) Link() string {
 // Check checks whether a resource defines multiple targets
 func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner tflint.Runner) error {
 	resources, err := runner.GetResourceContent(r.resourceType, &hclext.BodySchema{
-		Attributes: []hclext.AttributeSchema{
-			{Name: "gateway_id"},
-			{Name: "egress_only_gateway_id"},
-			{Name: "nat_gateway_id"},
-			{Name: "instance_id"},
-			{Name: "vpc_peering_connection_id"},
-			{Name: "network_interface_id"},
-			{Name: "transit_gateway_id"},
-			{Name: "vpc_endpoint_id"},
-			{Name: "carrier_gateway_id"},
-			{Name: "local_gateway_id"},
-		},
+		Attributes: routeTargetAttributes,
 	}, nil)
 	if err != nil {
 		return err

--- a/rules/aws_route_specified_multiple_targets_test.go
+++ b/rules/aws_route_specified_multiple_targets_test.go
@@ -43,6 +43,46 @@ resource "aws_route" "foo" {
 			Expected: helper.Issues{},
 		},
 		{
+			Name: "gateway_id and core_network_arn are both specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+    core_network_arn = "arn:aws:networkmanager::230703758040:core-network/core-network-0ce39423cf52b4c76"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsRouteSpecifiedMultipleTargetsRule(),
+					Message: "More than one routing target specified. It must be one.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "gateway_id and odb_network_arn are both specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+    odb_network_arn = "arn:aws:odb:us-east-1:230703758040:odb-network/odbnet-abcd1234"
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsRouteSpecifiedMultipleTargetsRule(),
+					Message: "More than one routing target specified. It must be one.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 27},
+					},
+				},
+			},
+		},
+		{
 			Name: "multiple targes found, but the second one is null",
 			Content: `
 resource "aws_route" "foo" {

--- a/rules/aws_route_targets.go
+++ b/rules/aws_route_targets.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+)
+
+// routeTargetAttributes are the mutually exclusive routing target arguments of
+// an aws_route resource, of which AWS requires exactly one.
+// aws_route_not_specified_target and aws_route_specified_multiple_targets check
+// that requirement from opposite directions and must agree on the set, since an
+// attribute missing from the schema is invisible to both.
+//
+// The provider expresses the mutual exclusion as an ExactlyOneOf, which does not
+// cross the plugin protocol, so the set cannot be derived from the provider
+// schema and is maintained here instead. TestRouteTargetAttributes fails when
+// the schema gains an aws_route argument this list does not classify.
+//
+// Sorted alphabetically: routeTargetNotSpecifiedMessage lists them in order.
+var routeTargetAttributes = []hclext.AttributeSchema{
+	{Name: "carrier_gateway_id"},
+	{Name: "core_network_arn"},
+	{Name: "egress_only_gateway_id"},
+	{Name: "gateway_id"},
+	{Name: "instance_id"},
+	{Name: "local_gateway_id"},
+	{Name: "nat_gateway_id"},
+	{Name: "network_interface_id"},
+	{Name: "odb_network_arn"},
+	{Name: "transit_gateway_id"},
+	{Name: "vpc_endpoint_id"},
+	{Name: "vpc_peering_connection_id"},
+}
+
+var routeTargetNotSpecifiedMessage = fmt.Sprintf(
+	"The routing target is not specified, each aws_route must contain either %s.",
+	routeTargetAlternatives(),
+)
+
+func routeTargetNames() []string {
+	names := make([]string, len(routeTargetAttributes))
+	for i, attribute := range routeTargetAttributes {
+		names[i] = attribute.Name
+	}
+	return names
+}
+
+func routeTargetAlternatives() string {
+	names := routeTargetNames()
+	return strings.Join(names[:len(names)-1], ", ") + " or " + names[len(names)-1]
+}

--- a/rules/aws_route_targets_test.go
+++ b/rules/aws_route_targets_test.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/terraform-linters/tflint-ruleset-aws/rules/genutils"
+)
+
+// knownNonTargetAttributes are the aws_route arguments that are not routing
+// targets. Together with routeTargetAttributes they account for every settable
+// attribute of the resource, so an argument added by the provider fails
+// TestRouteTargetAttributes until it is classified as one or the other. Both
+// aws_route target rules once silently missed core_network_arn and
+// odb_network_arn for exactly that reason.
+var knownNonTargetAttributes = []string{
+	"destination_cidr_block",
+	"destination_ipv6_cidr_block",
+	"destination_prefix_list_id",
+	"id",
+	"region",
+	"route_table_id",
+}
+
+func TestRouteTargetAttributes(t *testing.T) {
+	provider := genutils.LoadProviderSchema(filepath.Join("..", "tools", "provider-schema", "schema.json"))
+	route, exists := provider.ResourceSchemas["aws_route"]
+	if !exists {
+		t.Fatal("aws_route is missing from the provider schema")
+	}
+	names := routeTargetNames()
+
+	t.Run("every routing target exists in the provider schema", func(t *testing.T) {
+		for _, name := range names {
+			if route.Block.Attributes[name] == nil {
+				t.Errorf("aws_route no longer has a %s attribute", name)
+			}
+		}
+	})
+
+	t.Run("every settable attribute is classified", func(t *testing.T) {
+		for name, attribute := range route.Block.Attributes {
+			if !attribute.Optional && !attribute.Required {
+				continue
+			}
+			if slices.Contains(names, name) || slices.Contains(knownNonTargetAttributes, name) {
+				continue
+			}
+			t.Errorf("aws_route attribute %s is neither a routing target nor a known non-target: add it to routeTargetAttributes or knownNonTargetAttributes", name)
+		}
+	})
+
+	t.Run("routing targets are sorted", func(t *testing.T) {
+		if !slices.IsSorted(names) {
+			t.Errorf("routeTargetAttributes must be sorted because routeTargetNotSpecifiedMessage lists them in order, got %v", names)
+		}
+	})
+}

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -1,5 +1,30 @@
 package rules
 
+import "github.com/terraform-linters/tflint-plugin-sdk/hclext"
+
+// routeTargetAttributes is the set of mutually-exclusive routing target
+// arguments of an aws_route resource. AWS requires exactly one of these to be
+// set. It is shared by
+//
+// 1. aws_route_not_specified_target (errors when none is set)
+// 2. aws_route_specified_multiple_targets (errors when more than one is set)
+//
+// The two rules validate against an identical set so they cannot drift apart.
+var routeTargetAttributes = []hclext.AttributeSchema{
+	{Name: "gateway_id"},
+	{Name: "egress_only_gateway_id"},
+	{Name: "nat_gateway_id"},
+	{Name: "instance_id"},
+	{Name: "vpc_peering_connection_id"},
+	{Name: "network_interface_id"},
+	{Name: "transit_gateway_id"},
+	{Name: "vpc_endpoint_id"},
+	{Name: "carrier_gateway_id"},
+	{Name: "local_gateway_id"},
+	{Name: "core_network_arn"},
+	{Name: "odb_network_arn"},
+}
+
 var validElastiCacheNodeTypes = map[string]bool{
 	// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
 	"cache.t2.micro":      true,

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -1,30 +1,5 @@
 package rules
 
-import "github.com/terraform-linters/tflint-plugin-sdk/hclext"
-
-// routeTargetAttributes is the set of mutually-exclusive routing target
-// arguments of an aws_route resource. AWS requires exactly one of these to be
-// set. It is shared by
-//
-// 1. aws_route_not_specified_target (errors when none is set)
-// 2. aws_route_specified_multiple_targets (errors when more than one is set)
-//
-// The two rules validate against an identical set so they cannot drift apart.
-var routeTargetAttributes = []hclext.AttributeSchema{
-	{Name: "gateway_id"},
-	{Name: "egress_only_gateway_id"},
-	{Name: "nat_gateway_id"},
-	{Name: "instance_id"},
-	{Name: "vpc_peering_connection_id"},
-	{Name: "network_interface_id"},
-	{Name: "transit_gateway_id"},
-	{Name: "vpc_endpoint_id"},
-	{Name: "carrier_gateway_id"},
-	{Name: "local_gateway_id"},
-	{Name: "core_network_arn"},
-	{Name: "odb_network_arn"},
-}
-
 var validElastiCacheNodeTypes = map[string]bool{
 	// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
 	"cache.t2.micro":      true,


### PR DESCRIPTION
## What

The two `aws_route` routing-target rules each maintained their own copy of the
target attribute list, and both copies had drifted from the AWS provider's
documented route targets:

- **`aws_route_specified_multiple_targets`** did not include `core_network_arn`
  or `odb_network_arn`. Because attributes outside a rule's `BodySchema` are
  invisible to it, a route that combines one of these with another target (for
  example `gateway_id` + `core_network_arn`) was counted as a single target and
  passed silently. This is a **false negative**: a genuinely invalid
  multiple-target route was not flagged.
- **`aws_route_not_specified_target`** did not include `odb_network_arn`, so a
  route whose only target was `odb_network_arn` was reported as having no target
  (a **false positive**). Its error message also omitted `carrier_gateway_id`
  and `local_gateway_id`.

`odb_network_arn` (ARN of an ODB / Oracle Database@AWS network) and
`core_network_arn` are both documented, optional routing targets on `aws_route`.

## Changes

- Extract the routing-target attribute list into a single shared
  `routeTargetAttributes` slice in `rules/utils.go`, referenced by both rules so
  they can no longer drift apart.
- Align the shared list with the routing targets documented by the AWS provider
  (adds `core_network_arn` to the multiple-targets rule and `odb_network_arn` to
  both).
- Update the `aws_route_not_specified_target` message and its doc to enumerate
  every checked target.
- Add regression tests covering `core_network_arn` and `odb_network_arn` in both
  rules.

## Testing

`go build ./...`, `go vet ./rules/...`, and `go test ./rules/` all pass.