### PR TITLE
Fix aws_resource_missing_tags matching ASG tags across all ASGs (#1136)

### DIFF
--- a/rules/aws_resource_missing_tags.go
+++ b/rules/aws_resource_missing_tags.go
@@ -283,7 +283,7 @@ func (r *AwsResourceMissingTagsRule) checkAwsAutoScalingGroupsTag(runner tflint.
 	}
 
 	for _, resource := range resources.Blocks {
-		if resource.Labels[0] != resourceBlock.Labels[0] {
+		if resource.Labels[1] != resourceBlock.Labels[1] {
 			continue
 		}
 
@@ -320,7 +320,7 @@ func (r *AwsResourceMissingTagsRule) checkAwsAutoScalingGroupsTags(runner tflint
 	}
 
 	for _, resource := range resources.Blocks {
-		if resource.Labels[0] != resourceBlock.Labels[0] {
+		if resource.Labels[1] != resourceBlock.Labels[1] {
 			continue
 		}
 

--- a/rules/aws_resource_missing_tags_test.go
+++ b/rules/aws_resource_missing_tags_test.go
@@ -240,6 +240,91 @@ rule "aws_resource_missing_tags" {
 			},
 		},
 		{
+			Name: "AutoScaling Group each instance uses different required tags and each is reported missing one",
+			Content: `
+resource "aws_autoscaling_group" "asg_one" {
+  name = "repro-one"
+  tag {
+    key                 = "Foo"
+    value               = "one"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group" "asg_two" {
+  name = "repro-two"
+  tag {
+    key                 = "Bar"
+    value               = "two"
+    propagate_at_launch = true
+  }
+}`,
+			Config: `
+rule "aws_resource_missing_tags" {
+  enabled = true
+  tags = ["Foo", "Bar"]
+}`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsResourceMissingTagsRule(),
+					Message: "The resource is missing the following tags: \"Bar\".",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 43},
+					},
+				},
+				{
+					Rule:    NewAwsResourceMissingTagsRule(),
+					Message: "The resource is missing the following tags: \"Foo\".",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 11, Column: 1},
+						End:      hcl.Pos{Line: 11, Column: 43},
+					},
+				},
+			},
+		},
+		{
+			Name: "AutoScaling Group instances with only tag blocks or only tags attributes do not cross-report mixed-format errors",
+			Content: `
+resource "aws_autoscaling_group" "asg_tag_block" {
+  name = "repro-block"
+  tag {
+    key                 = "Foo"
+    value               = "one"
+    propagate_at_launch = true
+  }
+  tag {
+    key                 = "Bar"
+    value               = "two"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group" "asg_tags_attr" {
+  name = "repro-attr"
+  tags = [
+    {
+      key                 = "Foo"
+      value               = "one"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Bar"
+      value               = "two"
+      propagate_at_launch = true
+    }
+  ]
+}`,
+			Config: `
+rule "aws_resource_missing_tags" {
+  enabled = true
+  tags = ["Foo", "Bar"]
+}`,
+			Expected: helper.Issues{},
+		},
+		{
 			Name: "AutoScaling Group with no tags",
 			Content: `
 resource "aws_autoscaling_group" "asg" {


### PR DESCRIPTION
The `aws_resource_missing_tags` rule has a special case for `aws_autoscaling_group` resources, because ASGs support two different ways of specifying tags: the `tags` attribute and `tag` blocks. To handle both, the rule walks every ASG block in the module while checking a given resource.

The bug ([#1136](https://github.com/terraform-linters/tflint-ruleset-aws/issues/1136)) is that it matched blocks by resource type, which is the same for every ASG, so the check pooled all ASGs' tags together instead of scoping to the one being checked. As a result, required tags on one ASG counted toward another, and mixed tag styles across separate resources were reported as if one resource used both.

The one-line fix (in `checkAwsAutoScalingGroupsTag()` and `checkAwsAutoScalingGroupsTags()`) changes the comparison to match on the resource name, so each ASG is scoped to its own `tag` blocks and `tags` attribute.

### References
- Issue: [#1136](https://github.com/terraform-linters/tflint-ruleset-aws/issues/1136)
- ASG tag styles (`tag` block vs `tags` attribute): [`aws_autoscaling_group` provider docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#tag-and-tags)