### PR TITLE
Fix false end of support warning for new runtimes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 default: build
 
+# The generators tag is set so the generator packages and their tests, which
+# an untagged build excludes, are covered.
 test:
-	go test $$(go list ./... | grep -v integration)
+	go test -tags generators $$(go list -tags generators ./... | grep -v integration)
 
 e2e: 
 	cd integration && go test && cd ../

--- a/rules/lambda_deprecated_runtime/aws_lambda_function_deprecated_runtime.go
+++ b/rules/lambda_deprecated_runtime/aws_lambda_function_deprecated_runtime.go
@@ -67,7 +67,10 @@ func (r *AwsLambdaFunctionDeprecatedRuntimeRule) Check(runner tflint.Runner) err
 
 		err := runner.EvaluateExpr(attribute.Expr, func(val string) error {
 			rt, ok := r.runtimes.Runtimes[val]
-			if !ok || !r.Now.After(rt.EndOfSupportDate) {
+			// A zero end of support date means the data records no deprecation
+			// schedule for the runtime, not that it expired at the zero time,
+			// which is in the past for every possible value of Now.
+			if !ok || rt.EndOfSupportDate.IsZero() || !r.Now.After(rt.EndOfSupportDate) {
 				return nil
 			}
 

--- a/rules/lambda_deprecated_runtime/aws_lambda_function_deprecated_runtime_test.go
+++ b/rules/lambda_deprecated_runtime/aws_lambda_function_deprecated_runtime_test.go
@@ -26,6 +26,8 @@ func Test_AwsLambdaFunctionDeprecatedRuntime(t *testing.T) {
 			"nodejs22.x": {
 				EndOfSupportDate: time.Date(2027, time.April, 30, 0, 0, 0, 0, time.UTC),
 			},
+			// A runtime the generated data records no deprecation schedule for.
+			"python3.15": {},
 		},
 	}
 
@@ -75,6 +77,15 @@ func Test_AwsLambdaFunctionDeprecatedRuntime(t *testing.T) {
 					Message: `The "python3.9" runtime has reached end of support and function updates were scheduled to be blocked on Sep 30, 2026 (as of ` + stale + `)`,
 				},
 			},
+		},
+		{
+			// The zero end of support date is in the past for every possible
+			// value of Now, so an unguarded comparison reports every function
+			// using a runtime AWS has not scheduled for deprecation.
+			name:     "no scheduled end of support",
+			runtime:  "python3.15",
+			now:      time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC),
+			expected: helper.Issues{},
 		},
 		{
 			name:    "speculative end of support",
@@ -186,5 +197,26 @@ func Test_RuntimeMessage(t *testing.T) {
 	expected := `The "test" runtime has reached end of support and function updates are blocked`
 	if got != expected {
 		t.Errorf("confirmed block update: expected %q, got %q", expected, got)
+	}
+}
+
+// Guards the generated data against runtimes AWS has not scheduled for
+// deprecation. Such a runtime has no lifecycle to record and belongs out of
+// the data entirely, since a zero date reads as a date in the past.
+func Test_EmbeddedData_ScheduledDates(t *testing.T) {
+	if len(runtimes.Runtimes) == 0 {
+		t.Fatal("expected embedded data to contain runtimes")
+	}
+
+	for name, rt := range runtimes.Runtimes {
+		if rt.EndOfSupportDate.IsZero() {
+			t.Errorf("runtime %q has a zero end of support date", name)
+		}
+		if rt.BlockCreateDate != nil && rt.BlockCreateDate.IsZero() {
+			t.Errorf("runtime %q has a zero block create date", name)
+		}
+		if rt.BlockUpdateDate != nil && rt.BlockUpdateDate.IsZero() {
+			t.Errorf("runtime %q has a zero block update date", name)
+		}
 	}
 }

--- a/rules/lambda_deprecated_runtime/generator/main.go
+++ b/rules/lambda_deprecated_runtime/generator/main.go
@@ -14,8 +14,8 @@ import (
 )
 
 type output struct {
-	UpdatedAt time.Time                `json:"updated_at"`
-	Runtimes  map[string]runtimeEntry  `json:"runtimes"`
+	UpdatedAt time.Time               `json:"updated_at"`
+	Runtimes  map[string]runtimeEntry `json:"runtimes"`
 }
 
 type runtimeEntry struct {
@@ -118,10 +118,18 @@ func parseRow(cells []string) (string, runtimeEntry, bool) {
 		return "", runtimeEntry{}, false
 	}
 
+	// A runtime AWS has not scheduled for deprecation has no lifecycle to
+	// record. Emitting it with a zero end of support date would report every
+	// function using the runtime as having reached end of support.
+	endOfSupport, scheduled := parseDeprecationDate(cells[3])
+	if !scheduled {
+		return "", runtimeEntry{}, false
+	}
+
 	return identifier, runtimeEntry{
-		EndOfSupportDate: parseDate(cells[3]),
-		BlockCreateDate:  parseDatePtr(cells[4]),
-		BlockUpdateDate:  parseDatePtr(cells[5]),
+		EndOfSupportDate: endOfSupport,
+		BlockCreateDate:  parseBlockDate(cells[4]),
+		BlockUpdateDate:  parseBlockDate(cells[5]),
 	}, true
 }
 
@@ -135,27 +143,40 @@ func isRuntimeIdentifier(s string) bool {
 	return false
 }
 
-func parseDate(s string) time.Time {
-	t, _ := parseDateOpt(s)
-	return t
-}
-
-func parseDatePtr(s string) *time.Time {
-	t, ok := parseDateOpt(s)
-	if !ok {
-		return nil
-	}
-	return &t
-}
-
-func parseDateOpt(s string) (time.Time, bool) {
+// parseDateCell parses a date cell from the runtimes table. The values AWS
+// uses to mean "no date announced" report scheduled=false. An unrecognized
+// value means the table format changed and returns an error, leaving each
+// column to decide what a parse failure there costs.
+func parseDateCell(s string) (time.Time, bool, error) {
 	s = strings.TrimSpace(s)
 	if s == "" || s == "N/A" || s == "–" || strings.Contains(s, "Not scheduled") {
-		return time.Time{}, false
+		return time.Time{}, false, nil
 	}
 	t, err := time.Parse("Jan 2, 2006", s)
 	if err != nil {
-		return time.Time{}, false
+		return time.Time{}, false, err
 	}
-	return t, true
+	return t, true, nil
+}
+
+// parseDeprecationDate parses the column the whole schedule is keyed on, so an
+// unrecognized value panics rather than silently dropping the runtime.
+func parseDeprecationDate(s string) (time.Time, bool) {
+	date, scheduled, err := parseDateCell(s)
+	if err != nil {
+		panic(fmt.Sprintf("parsing deprecation date %q: %s", s, err))
+	}
+	return date, scheduled
+}
+
+// parseBlockDate parses one of the optional block columns. An unrecognized
+// value is absent rather than fatal, costing the reported message some
+// specificity where the same failure in the deprecation column would drop the
+// runtime entirely.
+func parseBlockDate(s string) *time.Time {
+	date, scheduled, _ := parseDateCell(s)
+	if !scheduled {
+		return nil
+	}
+	return &date
 }

--- a/rules/lambda_deprecated_runtime/generator/main_test.go
+++ b/rules/lambda_deprecated_runtime/generator/main_test.go
@@ -1,0 +1,277 @@
+//go:build generators
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// formatEntry renders an entry for comparison, avoiding time.Time equality
+// pitfalls around monotonic clock readings and location pointers.
+func formatEntry(e runtimeEntry) string {
+	optional := func(t *time.Time) string {
+		if t == nil {
+			return "none"
+		}
+		return t.Format("2006-01-02")
+	}
+	return fmt.Sprintf(
+		"eos=%s create=%s update=%s",
+		e.EndOfSupportDate.Format("2006-01-02"),
+		optional(e.BlockCreateDate),
+		optional(e.BlockUpdateDate),
+	)
+}
+
+func TestParseDeprecationDate(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		input     string
+		scheduled bool
+		expected  string
+	}{
+		{
+			name:      "full date",
+			input:     "Jun 30, 2029",
+			scheduled: true,
+			expected:  "2029-06-30",
+		},
+		{
+			name:      "single digit day",
+			input:     "Mar 5, 2020",
+			scheduled: true,
+			expected:  "2020-03-05",
+		},
+		{
+			name:      "surrounding whitespace",
+			input:     "  Nov 10, 2026\n",
+			scheduled: true,
+			expected:  "2026-11-10",
+		},
+		{
+			name:      "not scheduled",
+			input:     "Not scheduled",
+			scheduled: false,
+		},
+		{
+			name:      "not applicable",
+			input:     "N/A",
+			scheduled: false,
+		},
+		{
+			name:      "empty",
+			input:     "",
+			scheduled: false,
+		},
+		{
+			name:      "en dash",
+			input:     "–",
+			scheduled: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			date, scheduled := parseDeprecationDate(tc.input)
+			if scheduled != tc.scheduled {
+				t.Fatalf("expected scheduled %t, got %t", tc.scheduled, scheduled)
+			}
+			if !scheduled {
+				return
+			}
+			if got := date.Format("2006-01-02"); got != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+// An unrecognized deprecation date means the table format changed. Panicking
+// fails the scheduled maintenance job so the change is noticed.
+func TestParseDeprecationDateUnrecognized(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for an unrecognized deprecation date")
+		}
+	}()
+
+	parseDeprecationDate("30 June 2029")
+}
+
+func TestParseBlockDate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "full date",
+			input:    "Aug 31, 2029",
+			expected: "2029-08-31",
+		},
+		{
+			name:     "not scheduled",
+			input:    "Not scheduled",
+			expected: "none",
+		},
+		{
+			name:     "not applicable",
+			input:    "N/A",
+			expected: "none",
+		},
+		{
+			// A block date the generator cannot read costs the reported
+			// message some specificity. The same value in the deprecation
+			// column panics, since it would drop the runtime instead.
+			name:     "unrecognized value",
+			input:    "Aug 31, 2029 (estimated)",
+			expected: "none",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			date := parseBlockDate(tc.input)
+			got := "none"
+			if date != nil {
+				got = date.Format("2006-01-02")
+			}
+			if got != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseRow(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		cells    []string
+		ok       bool
+		expected string
+	}{
+		{
+			name:     "full lifecycle",
+			cells:    []string{"Python 3.13", "python3.13", "Amazon Linux 2023", "Jun 30, 2029", "Jul 31, 2029", "Aug 31, 2029"},
+			ok:       true,
+			expected: "eos=2029-06-30 create=2029-07-31 update=2029-08-31",
+		},
+		{
+			// dotnet7 and dotnet5.0 reached end of support without AWS ever
+			// scheduling the blocks.
+			name:     "end of support without blocks",
+			cells:    []string{".NET 7", "dotnet7", "Amazon Linux 2", "May 14, 2024", "N/A", "N/A"},
+			ok:       true,
+			expected: "eos=2024-05-14 create=none update=none",
+		},
+		{
+			name:     "blocks not yet scheduled",
+			cells:    []string{".NET 9", "dotnet9", "Amazon Linux 2023", "Nov 10, 2026", "Not scheduled", "Not scheduled"},
+			ok:       true,
+			expected: "eos=2026-11-10 create=none update=none",
+		},
+		{
+			// A supported runtime with no announced deprecation date. Emitting
+			// it with a zero end of support date reported every function using
+			// the runtime as deprecated.
+			name:  "no deprecation date scheduled",
+			cells: []string{"Python 3.15", "python3.15", "Amazon Linux 2023", "Not scheduled", "Not scheduled", "Not scheduled"},
+			ok:    false,
+		},
+		{
+			// An unreadable block column leaves that date absent and keeps
+			// the runtime on the schedule.
+			name:     "unrecognized block date",
+			cells:    []string{"Python 3.13", "python3.13", "Amazon Linux 2023", "Jun 30, 2029", "Jul 31, 2029 (estimated)", "Aug 31, 2029"},
+			ok:       true,
+			expected: "eos=2029-06-30 create=none update=2029-08-31",
+		},
+		{
+			name:  "header row",
+			cells: []string{"Name", "Identifier", "Operating system", "Deprecation date", "Block function create", "Block function update"},
+			ok:    false,
+		},
+		{
+			name:  "unrecognized identifier",
+			cells: []string{"Rust", "rust1.x", "Amazon Linux 2023", "Jun 30, 2029", "Jul 31, 2029", "Aug 31, 2029"},
+			ok:    false,
+		},
+		{
+			name:  "too few cells",
+			cells: []string{"Python 3.13", "python3.13", "Amazon Linux 2023"},
+			ok:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			identifier, entry, ok := parseRow(tc.cells)
+			if ok != tc.ok {
+				t.Fatalf("expected ok %t, got %t", tc.ok, ok)
+			}
+			if !ok {
+				return
+			}
+			if identifier != tc.cells[1] {
+				t.Errorf("expected identifier %s, got %s", tc.cells[1], identifier)
+			}
+			if got := formatEntry(entry); got != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+const runtimesPage = `
+<html><body>
+<table>
+  <tr>
+    <th>Name</th><th>Identifier</th><th>Operating system</th>
+    <th>Deprecation date</th><th>Block function create</th><th>Block function update</th>
+  </tr>
+  <tr>
+    <td>Node.js 26</td><td>nodejs26.x</td><td>Amazon Linux 2023</td>
+    <td>Not scheduled</td><td>Not scheduled</td><td>Not scheduled</td>
+  </tr>
+  <tr>
+    <td>Python 3.15</td><td>python3.15</td><td>Amazon Linux 2023</td>
+    <td>Not scheduled</td><td>Not scheduled</td><td>Not scheduled</td>
+  </tr>
+  <tr>
+    <td>Python 3.13</td><td>python3.13</td><td>Amazon Linux 2023</td>
+    <td>Jun 30, 2029</td><td>Jul 31, 2029</td><td>Aug 31, 2029</td>
+  </tr>
+  <tr>
+    <td>.NET 7</td><td>dotnet7</td><td>Amazon Linux 2</td>
+    <td>May 14, 2024</td><td>N/A</td><td>N/A</td>
+  </tr>
+</table>
+</body></html>
+`
+
+// Runtimes AWS has not scheduled for deprecation are absent from the output.
+// They were previously emitted with a zero end of support date, which the rule
+// read as a date in the past, reporting every function using a newly released
+// runtime as having reached end of support.
+func TestParseRuntimes(t *testing.T) {
+	entries := parseRuntimes(html.NewTokenizer(strings.NewReader(runtimesPage)))
+
+	expected := map[string]string{
+		"python3.13": "eos=2029-06-30 create=2029-07-31 update=2029-08-31",
+		"dotnet7":    "eos=2024-05-14 create=none update=none",
+	}
+
+	if len(entries) != len(expected) {
+		t.Fatalf("expected %d runtimes, got %d: %v", len(expected), len(entries), entries)
+	}
+
+	for identifier, want := range expected {
+		entry, ok := entries[identifier]
+		if !ok {
+			t.Errorf("expected runtime %s to be present", identifier)
+			continue
+		}
+		if got := formatEntry(entry); got != want {
+			t.Errorf("%s: expected %s, got %s", identifier, want, got)
+		}
+	}
+}


### PR DESCRIPTION
AWS lists a newly released Lambda runtime with "Not scheduled" in all three date columns of the [runtimes table](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).

`parseDate` discarded the parse-failure flag from `parseDateOpt` and returned the zero `time.Time`. `parseRow` emitted the runtime anyway:

```json
"python3.15": {
  "end_of_support_date": "0001-01-01T00:00:00Z"
}
```

The rule tests `Now.After(EndOfSupportDate)`, which is true for the zero time at every possible `Now`. The two newest runtimes AWS ships would warn as end of support on every function using them.

#1149 carries that data for `python3.15` and `nodejs26.x` today. It is where [this came up](https://github.com/terraform-linters/tflint-ruleset-aws/pull/1149#discussion_r3825509637).

## Column Strictness

`parseRow` skips a row whose deprecation date it cannot read. A runtime with no announced date has no lifecycle to record.

An unrecognized value in the deprecation column panics. The two block columns treat one as absent, because the costs differ.

A block date the generator cannot read leaves the field nil, and `runtimeMessage` short-circuits on nil. The warning only loses some specificity.

The same failure in the deprecation column drops the runtime from the schedule. Nothing would show a maintainer that the table changed. `maintenance.yaml` also runs `go generate ./...` across every generator in one step, so a panic there costs that week's entire update PR.

All 54 runtime rows on the live page carry a date, `N/A`, or `Not scheduled`. The parser recognizes all three.

## Rule Guard

`Check` treats a zero end of support date as no schedule recorded. `deprecated_runtimes.json` is checked in and regenerated by an unattended weekly job. The rule should not assume the generator is its only writer.

A test asserts the embedded data carries no zero dates.

## Test Coverage

`go list ./...` skips packages whose files all carry the `generators` build tag. `make test` never compiled the generator packages, so their tests have never run. That includes the existing `rules/models/generator/main_test.go`.

`make test` now sets the tag.

## Verification

Reverting the `parseRow` guard reproduces the reported output:

```
expected 2 runtimes, got 4:
  nodejs26.x {0001-01-01 00:00:00 +0000 UTC <nil> <nil>}
  python3.15 {0001-01-01 00:00:00 +0000 UTC <nil> <nil>}
```

Running the generator against the live page writes 52 runtimes with no zero dates. `python3.15` and `nodejs26.x` are absent.

I also built the plugin with `python3.15` injected at `0001-01-01` and ran tflint against a config using it. `python2.7` still warns and `python3.15` does not. The rule guard holds even if that data lands again.

#1149 needs its generated content refreshed once this merges, or those two entries dropped by hand.
