### PR TITLE
Fix time-dependent Lambda runtime message test

### DIFF
--- a/rules/lambda_deprecated_runtime/aws_lambda_function_deprecated_runtime_test.go
+++ b/rules/lambda_deprecated_runtime/aws_lambda_function_deprecated_runtime_test.go
@@ -140,7 +140,10 @@ resource "aws_lambda_function" "function" {
 }
 
 func Test_RuntimeMessage(t *testing.T) {
-	updatedAt := runtimes.UpdatedAt
+	// Fixed rather than taken from the generated data, whose UpdatedAt
+	// advances past the block dates below and turns the speculative cases
+	// into confirmed ones.
+	updatedAt := time.Date(2026, time.March, 29, 0, 0, 0, 0, time.UTC)
 	stale := updatedAt.Format("Jan 2, 2006")
 	blockCreate := time.Date(2026, time.August, 31, 0, 0, 0, 0, time.UTC)
 	blockUpdate := time.Date(2026, time.September, 30, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
`Test_RuntimeMessage` drew `updatedAt` from the embedded generated data rather than a fixture. That data's `updated_at` advances every time the generator runs. Beyond the Aug 31, 2026 block-create date the test hard-codes, `runtimeMessage` reports those runtimes as confirmed instead of scheduled. The regeneration in #1149 crossed that line.

Pins `updatedAt` to a fixed date, matching how `Test_AwsLambdaFunctionDeprecatedRuntime` already builds its own synthetic data.
