### PR TITLE
DynamoDB ARN should be accepted

### DIFF
--- a/rules/models/aws_dynamodb_kinesis_streaming_destination_invalid_table_name.go
+++ b/rules/models/aws_dynamodb_kinesis_streaming_destination_invalid_table_name.go
@@ -3,9 +3,6 @@
 package models
 
 import (
-	"fmt"
-	"regexp"
-
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/logger"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -19,7 +16,6 @@ type AwsDynamoDBKinesisStreamingDestinationInvalidTableNameRule struct {
 	attributeName string
 	max           int
 	min           int
-	pattern       *regexp.Regexp
 }
 
 // NewAwsDynamoDBKinesisStreamingDestinationInvalidTableNameRule returns new rule with default attributes
@@ -27,9 +23,8 @@ func NewAwsDynamoDBKinesisStreamingDestinationInvalidTableNameRule() *AwsDynamoD
 	return &AwsDynamoDBKinesisStreamingDestinationInvalidTableNameRule{
 		resourceType:  "aws_dynamodb_kinesis_streaming_destination",
 		attributeName: "table_name",
-		max:           255,
-		min:           3,
-		pattern:       regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`),
+		max:           1024,
+		min:           1,
 	}
 }
 
@@ -76,21 +71,14 @@ func (r *AwsDynamoDBKinesisStreamingDestinationInvalidTableNameRule) Check(runne
 			if len(val) > r.max {
 				runner.EmitIssue(
 					r,
-					"table_name must be 255 characters or less",
+					"table_name must be 1024 characters or less",
 					attribute.Expr.Range(),
 				)
 			}
 			if len(val) < r.min {
 				runner.EmitIssue(
 					r,
-					"table_name must be 3 characters or higher",
-					attribute.Expr.Range(),
-				)
-			}
-			if !r.pattern.MatchString(val) {
-				runner.EmitIssue(
-					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-zA-Z0-9_.-]+$`),
+					"table_name must be 1 characters or higher",
 					attribute.Expr.Range(),
 				)
 			}

--- a/rules/models/aws_dynamodb_table_item_invalid_table_name.go
+++ b/rules/models/aws_dynamodb_table_item_invalid_table_name.go
@@ -3,9 +3,6 @@
 package models
 
 import (
-	"fmt"
-	"regexp"
-
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/logger"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -19,7 +16,6 @@ type AwsDynamoDBTableItemInvalidTableNameRule struct {
 	attributeName string
 	max           int
 	min           int
-	pattern       *regexp.Regexp
 }
 
 // NewAwsDynamoDBTableItemInvalidTableNameRule returns new rule with default attributes
@@ -27,9 +23,8 @@ func NewAwsDynamoDBTableItemInvalidTableNameRule() *AwsDynamoDBTableItemInvalidT
 	return &AwsDynamoDBTableItemInvalidTableNameRule{
 		resourceType:  "aws_dynamodb_table_item",
 		attributeName: "table_name",
-		max:           255,
-		min:           3,
-		pattern:       regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`),
+		max:           1024,
+		min:           1,
 	}
 }
 
@@ -76,21 +71,14 @@ func (r *AwsDynamoDBTableItemInvalidTableNameRule) Check(runner tflint.Runner) e
 			if len(val) > r.max {
 				runner.EmitIssue(
 					r,
-					"table_name must be 255 characters or less",
+					"table_name must be 1024 characters or less",
 					attribute.Expr.Range(),
 				)
 			}
 			if len(val) < r.min {
 				runner.EmitIssue(
 					r,
-					"table_name must be 3 characters or higher",
-					attribute.Expr.Range(),
-				)
-			}
-			if !r.pattern.MatchString(val) {
-				runner.EmitIssue(
-					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-zA-Z0-9_.-]+$`),
+					"table_name must be 1 characters or higher",
 					attribute.Expr.Range(),
 				)
 			}

--- a/rules/models/mappings/dynamodb.hcl
+++ b/rules/models/mappings/dynamodb.hcl
@@ -7,7 +7,7 @@ mapping "aws_dynamodb_global_table" {
 
 mapping "aws_dynamodb_kinesis_streaming_destination" {
   stream_arn = StreamArn
-  table_name = TableName
+  table_name = TableArn
 }
 
 mapping "aws_dynamodb_table" {
@@ -28,7 +28,7 @@ mapping "aws_dynamodb_table" {
 }
 
 mapping "aws_dynamodb_table_item" {
-  table_name = TableName
+  table_name = TableArn
   hash_key   = KeySchemaAttributeName
   range_key  = KeySchemaAttributeName
   item       = AttributeMap
@@ -47,4 +47,3 @@ test "aws_dynamodb_table" "billing_mode" {
   ok = "PROVISIONED"
   ng = "FLEXIBLE"
 }
-


### PR DESCRIPTION
`aws_dynamodb_table_item.table_name` and `aws_dynamodb_kinesis_streaming_destination.table_name` were validated against DynamoDB's `TableName` shape, but that pattern only applies to operations that create a table. Both of these resources map to API operations that accept either a table name or an ARN in the same field. Previously passing a valid table ARN, which both TF and AWS API support incorrectly failed with `aws_dynamodb_table_item_invalid_table_name`.

Example failure:
```
Error: "arn:aws:dynamodb:us-east-1:id:table/table-name..." does not match valid pattern ^[a-zA-Z0-9_.-]+$ (aws_dynamodb_table_item_invalid_table_name)

  on dynamodb.tf line 77:
  77:   table_name = "arn:aws:dynamodb:us-east-1:id:table/table-name-..."
```